### PR TITLE
feat: add the has proxy for document

### DIFF
--- a/packages/runtime/browser-vm/src/modules/document.ts
+++ b/packages/runtime/browser-vm/src/modules/document.ts
@@ -5,6 +5,7 @@ import {
   createGetter,
   createSetter,
   createDefineProperty,
+  createHas,
 } from '../proxyInterceptor/document';
 
 const rawDocumentCtor = Document;
@@ -19,6 +20,7 @@ export const documentModule = (sandbox: Sandbox) => {
       microTaskHtmlProxyDocument(proxyDocument);
       return getter(...args);
     },
+    has: createHas(),
   });
 
   const fakeDocumentCtor = function Document() {

--- a/packages/runtime/browser-vm/src/proxyInterceptor/document.ts
+++ b/packages/runtime/browser-vm/src/proxyInterceptor/document.ts
@@ -115,3 +115,11 @@ export function createDefineProperty() {
       : Reflect.defineProperty(target, p, descriptor);
   };
 }
+
+// document proxy has
+export function createHas() {
+  return (target: any, p: PropertyKey) => {
+    if (p === 'activeElement') return Reflect.has(document, p);
+    return hasOwn(target, p) || Reflect.has(document, p);
+  };
+}


### PR DESCRIPTION
Some javascript libraries may use “key in document“ in if expression，up to now，these always return false。For example, https://github.com/sindresorhus/screenfull.js/blob/main/dist/screenfull.js
![image](https://user-images.githubusercontent.com/13704156/131955494-ff97f5cc-3a3d-4415-8171-21c64dca9454.png)
