### PR TITLE
fix(core): Fix the response mimeType of javascript requests my not be application/javascript

### DIFF
--- a/packages/browser-vm/src/dynamicNode/processor.ts
+++ b/packages/browser-vm/src/dynamicNode/processor.ts
@@ -123,7 +123,7 @@ export class DynamicNodeProcessor {
       if (src) {
         const fetchUrl = baseUrl ? transformUrl(baseUrl, src) : src;
         this.sandbox.loader
-          .load<JavaScriptManager>(namespace, fetchUrl)
+          .load<JavaScriptManager>(namespace, fetchUrl, false, true) // Fix the response mimeType of javascript request my not be application/javascript
           .then(({ resourceManager: { url, scriptCode } }) => {
             // It is necessary to ensure that the code execution error cannot trigger the `el.onerror` event
             setTimeout(() => {

--- a/packages/loader/src/index.ts
+++ b/packages/loader/src/index.ts
@@ -88,6 +88,7 @@ export class Loader {
     scope: string,
     url: string,
     isModule = false,
+    isScript = false, // Is from a dynamical script node
   ): Promise<LoadedHookArgs<T>['value']> {
     const { options, loadingList, cacheStore } = this;
 
@@ -135,7 +136,7 @@ export class Loader {
         } else if (isHtml(mimeType) || /\.html/.test(result.url)) {
           fileType = FileTypes.template;
           managerCtor = TemplateManager;
-        } else if (isJs(mimeType) || /\.js/.test(result.url)) {
+        } else if (isScript || isJs(mimeType) || /\.js/.test(result.url)) {
           fileType = FileTypes.js;
           managerCtor = JavaScriptManager;
         } else if (isCss(mimeType) || /\.css/.test(result.url)) {


### PR DESCRIPTION
如果js文件的content-type不是application/javascript，并且链接后缀不是.js，会导致js代码不会被执行。如果用户已经用script标签去加载资源了，应该默认是就是js代码。