### PR TITLE
Revert "fix(utils): Conversion relative path to the absolute path to failure is not blocked"

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,5 +90,5 @@
     "workspace-tools": "0.16.2",
     "zx": "4.2.0"
   },
-  "version": "1.0.12-beta.1"
+  "version": "1.0.11"
 }

--- a/packages/browser-snapshot/package.json
+++ b/packages/browser-snapshot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/browser-snapshot",
-  "version": "1.0.12-beta.1",
+  "version": "1.0.11",
   "description": "browser-snapshot module.",
   "keywords": [
     "garfish",

--- a/packages/browser-vm/package.json
+++ b/packages/browser-vm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/browser-vm",
-  "version": "1.0.12-beta.1",
+  "version": "1.0.11",
   "description": "vm-sandbox module.",
   "keywords": [
     "garfish",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/core",
-  "version": "1.0.12-beta.1",
+  "version": "1.0.11",
   "description": "core module.",
   "keywords": [
     "garfish",

--- a/packages/garfish/package.json
+++ b/packages/garfish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garfish",
-  "version": "1.0.12-beta.1",
+  "version": "1.0.11",
   "description": "garfish module.",
   "keywords": [
     "garfish",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/hooks",
-  "version": "1.0.12-beta.1",
+  "version": "1.0.11",
   "description": "hooks module.",
   "keywords": [
     "garfish",

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/loader",
-  "version": "1.0.12-beta.1",
+  "version": "1.0.11",
   "description": "loader module.",
   "keywords": [
     "garfish",

--- a/packages/remote-module/package.json
+++ b/packages/remote-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/remote-module",
-  "version": "1.0.12-beta.1",
+  "version": "1.0.11",
   "description": "remote-module module.",
   "keywords": [
     "garfish",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/router",
-  "version": "1.0.12-beta.1",
+  "version": "1.0.11",
   "description": "router module.",
   "keywords": [
     "garfish",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/utils",
-  "version": "1.0.12-beta.1",
+  "version": "1.0.11",
   "description": "utils module.",
   "keywords": [
     "garfish",

--- a/packages/utils/src/utils.ts
+++ b/packages/utils/src/utils.ts
@@ -325,14 +325,9 @@ export function isAbsolute(url: string) {
 }
 
 export function transformUrl(resolvePath: string, curPath: string) {
-  try {
-    const baseUrl = new URL(resolvePath, location.href);
-    const realPath = new URL(curPath, baseUrl.href);
-    return realPath.href;
-  } catch {
-    __DEV__ && warn(`resolvePath is ${resolvePath}, curPath is ${curPath} .Conversion failure`);
-    return curPath;
-  }
+  const baseUrl = new URL(resolvePath, location.href);
+  const realPath = new URL(curPath, baseUrl.href);
+  return realPath.href;
 }
 
 export function findTarget(


### PR DESCRIPTION
Reverts modern-js-dev/garfish#236