### PR TITLE
fix: webpack lazyload and with setImmediate Polyfill make Promise the…

### DIFF
--- a/packages/browser-vm/src/modules/timer.ts
+++ b/packages/browser-vm/src/modules/timer.ts
@@ -65,6 +65,13 @@ export const intervalModule = () => {
     override: {
       setInterval,
       clearInterval,
+      // webpack lazy use Promise
+      // Promise is polyfill
+      // polyfill Promise include Promise._setImmediate use setImmediate methods
+      // setImmediate polyfill postMessage as marco tasks
+      // postMessage callback judge event.source === window
+      // use setTimeout as setImmediate avoid judge fail
+      setImmediate: (fn) => setTimeout(fn, 0),
     },
   };
 };


### PR DESCRIPTION
- webpack lazy use Promise
- Promise is polyfill
- polyfill Promise include Promise._setImmediate use setImmediate methods
- setImmediate polyfill postMessage as marco tasks
- postMessage callback judge event.source === window
- use setTimeout as setImmediate avoid judge fail