### PR TITLE
feat: support style component

### DIFF
--- a/packages/browser-vm/__tests__/dom.spec.ts
+++ b/packages/browser-vm/__tests__/dom.spec.ts
@@ -1,5 +1,9 @@
 import { Sandbox } from '../src/sandbox';
 import { sandboxMap } from '../src/utils';
+import {
+  recordStyledComponentCSSRules,
+  rebuildCSSRules,
+} from '../src/dynamicNode';
 
 // Garfish 使用 Proxy 对 dom 进行了劫持, 同时对调用 dom 的函数做了劫持, 修正 dom 节点的类型
 // 对调用 dom 的相关方法进行测试
@@ -154,5 +158,50 @@ describe('Sandbox:Dom & Bom', () => {
       `),
       { next },
     );
+  });
+
+  const createStyleComponentElementWithRecord = () => {
+    const styleComponentElement = document.createElement('style');
+    document.head.appendChild(styleComponentElement);
+    const cssRuleExample1 = '.test1 { color: red }';
+    const cssRuleExample2 = '.test2 { color: red }';
+    styleComponentElement.sheet?.insertRule(`${cssRuleExample1}`);
+    styleComponentElement.sheet?.insertRule(`${cssRuleExample2}`);
+    sandbox.dynamicStyleSheetElementSet.add(styleComponentElement);
+
+    recordStyledComponentCSSRules(
+      sandbox.dynamicStyleSheetElementSet,
+      sandbox.styledComponentCSSRulesMap,
+    );
+    return styleComponentElement;
+  };
+
+  it('should record the css rules of styled-components correctly', () => {
+    const styleComponentElement = createStyleComponentElementWithRecord();
+    const cssRules = sandbox.styledComponentCSSRulesMap.get(
+      styleComponentElement,
+    );
+    expect(cssRules?.length).toEqual(2);
+    expect((cssRules?.[0] as CSSStyleRule).selectorText).toEqual('.test2');
+    expect((cssRules?.[1] as CSSStyleRule).selectorText).toEqual('.test1');
+  });
+
+  it('should rebuild the css rules of styled-components in the correct order', () => {
+    const styleComponentElement = createStyleComponentElementWithRecord();
+
+    Object.defineProperty(window.HTMLStyleElement.prototype, 'sheet', {
+      writable: true,
+      value: {},
+    });
+    // @ts-ignore
+    styleComponentElement.sheet = new CSSStyleSheet();
+    rebuildCSSRules(
+      sandbox.dynamicStyleSheetElementSet,
+      sandbox.styledComponentCSSRulesMap,
+    );
+    const cssRules = styleComponentElement.sheet.cssRules;
+    expect(cssRules.length).toEqual(2);
+    expect((cssRules?.[0] as CSSStyleRule).selectorText).toEqual('.test2');
+    expect((cssRules?.[1] as CSSStyleRule).selectorText).toEqual('.test1');
   });
 });

--- a/packages/browser-vm/src/dynamicNode/processor.ts
+++ b/packages/browser-vm/src/dynamicNode/processor.ts
@@ -251,6 +251,7 @@ export class DynamicNodeProcessor {
         this.el.textContent = manager.styleCode;
       }
       convertedNode = this.el;
+      this.sandbox.dynamicStyleSheetElementSet.add(this.el);
     }
     // The link node of the request css needs to be changed to style node
     else if (this.is('link')) {
@@ -318,8 +319,13 @@ export class DynamicNodeProcessor {
         context,
         this.is('script') ? 'body' : 'head',
       );
-      if (this.el.parentNode === parentNode)
+
+      if (this.el.parentNode === parentNode) {
+        if (this.sandbox.dynamicStyleSheetElementSet.has(this.el)) {
+          this.sandbox.dynamicStyleSheetElementSet.delete(this.el);
+        }
         return this.nativeRemove.call(parentNode, this.el);
+      }
     }
     return originProcess();
   }

--- a/packages/browser-vm/src/pluginify.ts
+++ b/packages/browser-vm/src/pluginify.ts
@@ -2,7 +2,7 @@ import { interfaces } from '@garfish/core';
 import { warn, isPlainObject } from '@garfish/utils';
 import { Module } from './types';
 import { Sandbox } from './sandbox';
-import { sandboxMap } from './utils';
+import { recordStyledComponentCSSRules, rebuildCSSRules } from './dynamicNode';
 
 declare module '@garfish/core' {
   export default interface Garfish {
@@ -126,6 +126,15 @@ function createOptions(Garfish: interfaces.Garfish) {
       );
     },
 
+    beforeUnmount(appInfo, appInstance) {
+      if (appInstance.vmSandbox) {
+        recordStyledComponentCSSRules(
+          appInstance.vmSandbox.dynamicStyleSheetElementSet,
+          appInstance.vmSandbox.styledComponentCSSRulesMap,
+        );
+      }
+    },
+
     // If the app is uninstalled, the sandbox needs to clear all effects and then reset
     afterUnmount(appInfo, appInstance, isCacheMode) {
       // The caching pattern to retain the same context
@@ -136,6 +145,10 @@ function createOptions(Garfish: interfaces.Garfish) {
 
     afterMount(appInfo, appInstance) {
       if (appInstance.vmSandbox) {
+        rebuildCSSRules(
+          appInstance.vmSandbox.dynamicStyleSheetElementSet,
+          appInstance.vmSandbox.styledComponentCSSRulesMap,
+        );
         appInstance.vmSandbox.execScript(`
           if (typeof window.onload === 'function') {
             window.onload.call(window);

--- a/packages/browser-vm/src/sandbox.ts
+++ b/packages/browser-vm/src/sandbox.ts
@@ -77,6 +77,11 @@ export class Sandbox {
   public isExternalGlobalVariable: Set<PropertyKey> = new Set();
   public isProtectVariable: (p: PropertyKey) => boolean;
   public isInsulationVariable: (P: PropertyKey) => boolean;
+  public dynamicStyleSheetElementSet = new Set<HTMLStyleElement>();
+  public styledComponentCSSRulesMap = new WeakMap<
+    HTMLStyleElement,
+    CSSRuleList
+  >();
 
   private optimizeCode = ''; // To optimize the with statement
   private tempVariable = '__sandbox_temp_vars__';
@@ -148,6 +153,7 @@ export class Sandbox {
     this.initComplete = false;
     this.deferClearEffects.clear();
     this.isExternalGlobalVariable.clear();
+    this.dynamicStyleSheetElementSet.clear();
     this.replaceGlobalVariables.createdList = [];
     this.replaceGlobalVariables.prepareList = [];
     this.replaceGlobalVariables.recoverList = [];

--- a/packages/browser-vm/src/utils.ts
+++ b/packages/browser-vm/src/utils.ts
@@ -161,3 +161,12 @@ export function microTaskHtmlProxyDocument(proxyDocument) {
     }
   }
 }
+
+export function isStyledComponentsLike(element: HTMLStyleElement) {
+  // A styled-components liked element has no textContent but keep the rules in its sheet.cssRules.
+  return (
+    element instanceof HTMLStyleElement &&
+    !element.textContent &&
+    element.sheet?.cssRules.length
+  );
+}


### PR DESCRIPTION
[style-components](https://styled-components.com/docs/api#stylesheetmanager)在生产环境下，默认样式是通过[insertRule](https://developer.mozilla.org/zh-CN/docs/Web/API/CSSStyleSheet/insertRule) api插入样式规则的（而不是传统的样式文本），这种style标签有个问题，在dom节点被卸载后，sheet数据就丢失了的，所以需要记录和还原。