### PR TITLE
Fix/is function.prototype.toString isn't function and onselectstart、ondragstart can't set to proxy document

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,5 +92,5 @@
   "engines": {
     "node": ">=14.13.0"
   },
-  "version": "1.1.5"
+  "version": "1.1.6-beta.1"
 }

--- a/package.json
+++ b/package.json
@@ -92,5 +92,5 @@
   "engines": {
     "node": ">=14.13.0"
   },
-  "version": "1.1.6-beta.5"
+  "version": "1.1.6-beta.6"
 }

--- a/package.json
+++ b/package.json
@@ -92,5 +92,5 @@
   "engines": {
     "node": ">=14.13.0"
   },
-  "version": "1.1.6-beta.3"
+  "version": "1.1.6-beta.4"
 }

--- a/package.json
+++ b/package.json
@@ -92,5 +92,5 @@
   "engines": {
     "node": ">=14.13.0"
   },
-  "version": "1.1.6-beta.4"
+  "version": "1.1.6-beta.5"
 }

--- a/package.json
+++ b/package.json
@@ -92,5 +92,5 @@
   "engines": {
     "node": ">=14.13.0"
   },
-  "version": "1.1.6-beta.6"
+  "version": "1.1.6-beta.7"
 }

--- a/package.json
+++ b/package.json
@@ -92,5 +92,5 @@
   "engines": {
     "node": ">=14.13.0"
   },
-  "version": "1.1.6-beta.1"
+  "version": "1.1.6-beta.3"
 }

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/bridge",
-  "version": "1.1.6-beta.3",
+  "version": "1.1.6-beta.4",
   "description": "garfish module.",
   "keywords": [
     "garfish",

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/bridge",
-  "version": "1.1.6-beta.4",
+  "version": "1.1.6-beta.5",
   "description": "garfish module.",
   "keywords": [
     "garfish",

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/bridge",
-  "version": "1.1.5",
+  "version": "1.1.6-beta.1",
   "description": "garfish module.",
   "keywords": [
     "garfish",

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/bridge",
-  "version": "1.1.6-beta.1",
+  "version": "1.1.6-beta.3",
   "description": "garfish module.",
   "keywords": [
     "garfish",

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/bridge",
-  "version": "1.1.6",
+  "version": "1.1.6-beta.7",
   "description": "garfish module.",
   "keywords": [
     "garfish",

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@garfish/bridge",
-<<<<<<< HEAD
-  "version": "1.1.6-beta.6",
-=======
   "version": "1.1.6",
->>>>>>> master
   "description": "garfish module.",
   "keywords": [
     "garfish",

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/bridge",
-  "version": "1.1.6-beta.5",
+  "version": "1.1.6-beta.6",
   "description": "garfish module.",
   "keywords": [
     "garfish",

--- a/packages/browser-snapshot/package.json
+++ b/packages/browser-snapshot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/browser-snapshot",
-  "version": "1.1.6",
+  "version": "1.1.6-beta.7",
   "description": "browser-snapshot module.",
   "keywords": [
     "garfish",

--- a/packages/browser-snapshot/package.json
+++ b/packages/browser-snapshot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/browser-snapshot",
-  "version": "1.1.6-beta.1",
+  "version": "1.1.6-beta.3",
   "description": "browser-snapshot module.",
   "keywords": [
     "garfish",

--- a/packages/browser-snapshot/package.json
+++ b/packages/browser-snapshot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/browser-snapshot",
-  "version": "1.1.5",
+  "version": "1.1.6-beta.1",
   "description": "browser-snapshot module.",
   "keywords": [
     "garfish",

--- a/packages/browser-snapshot/package.json
+++ b/packages/browser-snapshot/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@garfish/browser-snapshot",
-<<<<<<< HEAD
-  "version": "1.1.6-beta.6",
-=======
   "version": "1.1.6",
->>>>>>> master
   "description": "browser-snapshot module.",
   "keywords": [
     "garfish",

--- a/packages/browser-snapshot/package.json
+++ b/packages/browser-snapshot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/browser-snapshot",
-  "version": "1.1.6-beta.3",
+  "version": "1.1.6-beta.4",
   "description": "browser-snapshot module.",
   "keywords": [
     "garfish",

--- a/packages/browser-snapshot/package.json
+++ b/packages/browser-snapshot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/browser-snapshot",
-  "version": "1.1.6-beta.5",
+  "version": "1.1.6-beta.6",
   "description": "browser-snapshot module.",
   "keywords": [
     "garfish",

--- a/packages/browser-snapshot/package.json
+++ b/packages/browser-snapshot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/browser-snapshot",
-  "version": "1.1.6-beta.4",
+  "version": "1.1.6-beta.5",
   "description": "browser-snapshot module.",
   "keywords": [
     "garfish",

--- a/packages/browser-vm/package.json
+++ b/packages/browser-vm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/browser-vm",
-  "version": "1.1.5",
+  "version": "1.1.6-beta.1",
   "description": "vm-sandbox module.",
   "keywords": [
     "garfish",

--- a/packages/browser-vm/package.json
+++ b/packages/browser-vm/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@garfish/browser-vm",
-<<<<<<< HEAD
-  "version": "1.1.6-beta.6",
-=======
   "version": "1.1.6",
->>>>>>> master
   "description": "vm-sandbox module.",
   "keywords": [
     "garfish",

--- a/packages/browser-vm/package.json
+++ b/packages/browser-vm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/browser-vm",
-  "version": "1.1.6-beta.4",
+  "version": "1.1.6-beta.5",
   "description": "vm-sandbox module.",
   "keywords": [
     "garfish",

--- a/packages/browser-vm/package.json
+++ b/packages/browser-vm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/browser-vm",
-  "version": "1.1.6",
+  "version": "1.1.6-beta.7",
   "description": "vm-sandbox module.",
   "keywords": [
     "garfish",

--- a/packages/browser-vm/package.json
+++ b/packages/browser-vm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/browser-vm",
-  "version": "1.1.6-beta.5",
+  "version": "1.1.6-beta.6",
   "description": "vm-sandbox module.",
   "keywords": [
     "garfish",

--- a/packages/browser-vm/package.json
+++ b/packages/browser-vm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/browser-vm",
-  "version": "1.1.6-beta.3",
+  "version": "1.1.6-beta.4",
   "description": "vm-sandbox module.",
   "keywords": [
     "garfish",

--- a/packages/browser-vm/package.json
+++ b/packages/browser-vm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/browser-vm",
-  "version": "1.1.6-beta.1",
+  "version": "1.1.6-beta.3",
   "description": "vm-sandbox module.",
   "keywords": [
     "garfish",

--- a/packages/browser-vm/src/pluginify.ts
+++ b/packages/browser-vm/src/pluginify.ts
@@ -140,7 +140,9 @@ function createOptions(Garfish: interfaces.Garfish) {
     afterUnmount(appInfo, appInstance, isCacheMode) {
       // The caching pattern to retain the same context
       if (appInstance.vmSandbox && !isCacheMode) {
-        appInstance.vmSandbox.reset();
+        setTimeout(() => {
+          appInstance.vmSandbox.reset();
+        });
       }
     },
 

--- a/packages/browser-vm/src/proxyInterceptor/document.ts
+++ b/packages/browser-vm/src/proxyInterceptor/document.ts
@@ -11,7 +11,7 @@ import { rootElm, sandboxMap } from '../utils';
 import { __documentBind__ } from '../symbolTypes';
 import { bind, verifyGetterDescriptor, verifySetterDescriptor } from './shared';
 
-const passedKey = makeMap(['title', 'cookie']);
+const passedKey = makeMap(['title', 'cookie', 'onselectstart', 'ondragstart']);
 
 const queryFunctions = makeMap([
   'querySelector',
@@ -101,7 +101,7 @@ export function createSetter(sandbox) {
     }
 
     // Application area of the ban on selected, if users want to ban the global need to set on the main application
-    if (p === 'onselectstart') {
+    if (p === 'onselectstart' || p === 'ondragstart') {
       if (rootNode) {
         return Reflect.set(rootNode, p, value);
       } else {

--- a/packages/browser-vm/src/proxyInterceptor/document.ts
+++ b/packages/browser-vm/src/proxyInterceptor/document.ts
@@ -112,15 +112,19 @@ export function createSetter(sandbox) {
       }
     }
 
-    return typeof p === 'string' && passedKey(p)
-      ? Reflect.set(document, p, value)
-      : Reflect.set(target, p, value, receiver);
+    if (typeof p === 'string' && passedKey(p)) {
+      return Reflect.set(document, p, value);
+    } else {
+      safariProxyDocumentDealHandler.triggerSet();
+      return Reflect.set(target, p, value, receiver);
+    }
   };
 }
 
 // document proxy defineProperty
 export function createDefineProperty() {
   return (target: any, p: PropertyKey, descriptor: PropertyDescriptor) => {
+    safariProxyDocumentDealHandler.handleDescriptor(descriptor);
     return passedKey(p)
       ? Reflect.defineProperty(document, p, descriptor)
       : Reflect.defineProperty(target, p, descriptor);

--- a/packages/browser-vm/src/proxyInterceptor/document.ts
+++ b/packages/browser-vm/src/proxyInterceptor/document.ts
@@ -5,6 +5,7 @@ import {
   findTarget,
   __MockBody__,
   __MockHead__,
+  safari13Deal,
 } from '@garfish/utils';
 import { Sandbox } from '../sandbox';
 import { rootElm, sandboxMap } from '../utils';
@@ -82,6 +83,8 @@ export function createGetter(sandbox: Sandbox) {
     return value;
   };
 }
+
+const safariProxyDocumentDealHandler = safari13Deal();
 
 // document proxy setter
 export function createSetter(sandbox) {

--- a/packages/browser-vm/src/proxyInterceptor/shared.ts
+++ b/packages/browser-vm/src/proxyInterceptor/shared.ts
@@ -88,7 +88,9 @@ export function isConstructor(fn: () => void | FunctionConstructor) {
   const fp = fn.prototype;
   const hasConstructor =
     fp && fp.constructor === fn && Object.getOwnPropertyNames(fp).length > 1;
-  const functionStr = !hasConstructor && fn.toString();
+  const functionStr =
+    (!hasConstructor && typeof fn.toString === 'function' && fn.toString()) ||
+    '';
 
   return (
     hasConstructor ||

--- a/packages/browser-vm/src/proxyInterceptor/shared.ts
+++ b/packages/browser-vm/src/proxyInterceptor/shared.ts
@@ -84,13 +84,19 @@ export function verifySetterDescriptor(
   return 0;
 }
 
+function safeToString(thing) {
+  try {
+    return thing.toString();
+  } catch (e) {
+    return '[toString failed]';
+  }
+}
+
 export function isConstructor(fn: () => void | FunctionConstructor) {
   const fp = fn.prototype;
   const hasConstructor =
     fp && fp.constructor === fn && Object.getOwnPropertyNames(fp).length > 1;
-  const functionStr =
-    (!hasConstructor && typeof fn.toString === 'function' && fn.toString()) ||
-    '';
+  const functionStr = !hasConstructor && safeToString(fn);
 
   return (
     hasConstructor ||

--- a/packages/browser-vm/src/sandbox.ts
+++ b/packages/browser-vm/src/sandbox.ts
@@ -258,31 +258,8 @@ export class Sandbox {
         return `${prevCode} let ${name} = window.${name};`;
       }, code);
 
-      // defineProperty(target, p, descriptor) {
-      // safari 13.x set proxy global defineProperty descriptor default is { enumerable: false, configurable: false }
-      // verifySetterDescriptor will failure
-      // Proxy object's 'set' trap returned falsy value
-      // new Proxy({},{ return Reflect.defineProperty(target, p, descriptor) } })
-      // Used to update the variables synchronously after `window.x = xx` is updated
-      Object.defineProperty(this.global, `${GARFISH_OPTIMIZE_NAME}Methods`, {
-        get() {
-          return methods;
-        },
-        enumerable: true,
-        configurable: true,
-      });
-      Object.defineProperty(
-        this.global,
-        `${GARFISH_OPTIMIZE_NAME}UpdateStack`,
-        {
-          get() {
-            return [];
-          },
-          enumerable: true,
-          configurable: true,
-        },
-      );
-
+      this.global[`${GARFISH_OPTIMIZE_NAME}Methods`] = methods;
+      this.global[`${GARFISH_OPTIMIZE_NAME}UpdateStack`] = [];
       code += `window.${GARFISH_OPTIMIZE_NAME}UpdateStack.push(function(k,v){eval(k+"=v")});`;
     }
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/core",
-  "version": "1.1.6-beta.5",
+  "version": "1.1.6-beta.6",
   "description": "core module.",
   "keywords": [
     "garfish",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@garfish/core",
-<<<<<<< HEAD
-  "version": "1.1.6-beta.6",
-=======
   "version": "1.1.6",
->>>>>>> master
   "description": "core module.",
   "keywords": [
     "garfish",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/core",
-  "version": "1.1.6-beta.4",
+  "version": "1.1.6-beta.5",
   "description": "core module.",
   "keywords": [
     "garfish",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/core",
-  "version": "1.1.6-beta.3",
+  "version": "1.1.6-beta.4",
   "description": "core module.",
   "keywords": [
     "garfish",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/core",
-  "version": "1.1.6-beta.1",
+  "version": "1.1.6-beta.3",
   "description": "core module.",
   "keywords": [
     "garfish",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/core",
-  "version": "1.1.5",
+  "version": "1.1.6-beta.1",
   "description": "core module.",
   "keywords": [
     "garfish",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/core",
-  "version": "1.1.6",
+  "version": "1.1.6-beta.7",
   "description": "core module.",
   "keywords": [
     "garfish",

--- a/packages/garfish/package.json
+++ b/packages/garfish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garfish",
-  "version": "1.1.6-beta.5",
+  "version": "1.1.6-beta.6",
   "description": "garfish module.",
   "keywords": [
     "garfish",

--- a/packages/garfish/package.json
+++ b/packages/garfish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garfish",
-  "version": "1.1.5",
+  "version": "1.1.6-beta.1",
   "description": "garfish module.",
   "keywords": [
     "garfish",

--- a/packages/garfish/package.json
+++ b/packages/garfish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garfish",
-  "version": "1.1.6-beta.4",
+  "version": "1.1.6-beta.5",
   "description": "garfish module.",
   "keywords": [
     "garfish",

--- a/packages/garfish/package.json
+++ b/packages/garfish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garfish",
-  "version": "1.1.6-beta.1",
+  "version": "1.1.6-beta.3",
   "description": "garfish module.",
   "keywords": [
     "garfish",

--- a/packages/garfish/package.json
+++ b/packages/garfish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garfish",
-  "version": "1.1.6-beta.3",
+  "version": "1.1.6-beta.4",
   "description": "garfish module.",
   "keywords": [
     "garfish",

--- a/packages/garfish/package.json
+++ b/packages/garfish/package.json
@@ -1,10 +1,6 @@
 {
   "name": "garfish",
-<<<<<<< HEAD
-  "version": "1.1.6-beta.6",
-=======
   "version": "1.1.6",
->>>>>>> master
   "description": "garfish module.",
   "keywords": [
     "garfish",

--- a/packages/garfish/package.json
+++ b/packages/garfish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garfish",
-  "version": "1.1.6",
+  "version": "1.1.6-beta.7",
   "description": "garfish module.",
   "keywords": [
     "garfish",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/hooks",
-  "version": "1.1.6-beta.1",
+  "version": "1.1.6-beta.3",
   "description": "hooks module.",
   "keywords": [
     "garfish",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/hooks",
-  "version": "1.1.6",
+  "version": "1.1.6-beta.7",
   "description": "hooks module.",
   "keywords": [
     "garfish",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/hooks",
-  "version": "1.1.6-beta.4",
+  "version": "1.1.6-beta.5",
   "description": "hooks module.",
   "keywords": [
     "garfish",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@garfish/hooks",
-<<<<<<< HEAD
-  "version": "1.1.6-beta.6",
-=======
   "version": "1.1.6",
->>>>>>> master
   "description": "hooks module.",
   "keywords": [
     "garfish",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/hooks",
-  "version": "1.1.6-beta.3",
+  "version": "1.1.6-beta.4",
   "description": "hooks module.",
   "keywords": [
     "garfish",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/hooks",
-  "version": "1.1.6-beta.5",
+  "version": "1.1.6-beta.6",
   "description": "hooks module.",
   "keywords": [
     "garfish",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/hooks",
-  "version": "1.1.5",
+  "version": "1.1.6-beta.1",
   "description": "hooks module.",
   "keywords": [
     "garfish",

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/loader",
-  "version": "1.1.6",
+  "version": "1.1.6-beta.7",
   "description": "loader module.",
   "keywords": [
     "garfish",

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/loader",
-  "version": "1.1.6-beta.4",
+  "version": "1.1.6-beta.5",
   "description": "loader module.",
   "keywords": [
     "garfish",

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/loader",
-  "version": "1.1.6-beta.5",
+  "version": "1.1.6-beta.6",
   "description": "loader module.",
   "keywords": [
     "garfish",

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/loader",
-  "version": "1.1.6-beta.3",
+  "version": "1.1.6-beta.4",
   "description": "loader module.",
   "keywords": [
     "garfish",

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/loader",
-  "version": "1.1.5",
+  "version": "1.1.6-beta.1",
   "description": "loader module.",
   "keywords": [
     "garfish",

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/loader",
-  "version": "1.1.6-beta.1",
+  "version": "1.1.6-beta.3",
   "description": "loader module.",
   "keywords": [
     "garfish",

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@garfish/loader",
-<<<<<<< HEAD
-  "version": "1.1.6-beta.6",
-=======
   "version": "1.1.6",
->>>>>>> master
   "description": "loader module.",
   "keywords": [
     "garfish",

--- a/packages/remote-module/package.json
+++ b/packages/remote-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/remote-module",
-  "version": "1.1.6-beta.4",
+  "version": "1.1.6-beta.5",
   "description": "remote-module module.",
   "keywords": [
     "garfish",

--- a/packages/remote-module/package.json
+++ b/packages/remote-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/remote-module",
-  "version": "1.1.6-beta.3",
+  "version": "1.1.6-beta.4",
   "description": "remote-module module.",
   "keywords": [
     "garfish",

--- a/packages/remote-module/package.json
+++ b/packages/remote-module/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@garfish/remote-module",
-<<<<<<< HEAD
-  "version": "1.1.6-beta.6",
-=======
   "version": "1.1.6",
->>>>>>> master
   "description": "remote-module module.",
   "keywords": [
     "garfish",

--- a/packages/remote-module/package.json
+++ b/packages/remote-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/remote-module",
-  "version": "1.1.6",
+  "version": "1.1.6-beta.7",
   "description": "remote-module module.",
   "keywords": [
     "garfish",

--- a/packages/remote-module/package.json
+++ b/packages/remote-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/remote-module",
-  "version": "1.1.6-beta.1",
+  "version": "1.1.6-beta.3",
   "description": "remote-module module.",
   "keywords": [
     "garfish",

--- a/packages/remote-module/package.json
+++ b/packages/remote-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/remote-module",
-  "version": "1.1.6-beta.5",
+  "version": "1.1.6-beta.6",
   "description": "remote-module module.",
   "keywords": [
     "garfish",

--- a/packages/remote-module/package.json
+++ b/packages/remote-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/remote-module",
-  "version": "1.1.5",
+  "version": "1.1.6-beta.1",
   "description": "remote-module module.",
   "keywords": [
     "garfish",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/router",
-  "version": "1.1.6-beta.4",
+  "version": "1.1.6-beta.5",
   "description": "router module.",
   "keywords": [
     "garfish",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/router",
-  "version": "1.1.6-beta.1",
+  "version": "1.1.6-beta.3",
   "description": "router module.",
   "keywords": [
     "garfish",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/router",
-  "version": "1.1.5",
+  "version": "1.1.6-beta.1",
   "description": "router module.",
   "keywords": [
     "garfish",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/router",
-  "version": "1.1.6-beta.3",
+  "version": "1.1.6-beta.4",
   "description": "router module.",
   "keywords": [
     "garfish",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/router",
-  "version": "1.1.6",
+  "version": "1.1.6-beta.7",
   "description": "router module.",
   "keywords": [
     "garfish",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@garfish/router",
-<<<<<<< HEAD
-  "version": "1.1.6-beta.6",
-=======
   "version": "1.1.6",
->>>>>>> master
   "description": "router module.",
   "keywords": [
     "garfish",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/router",
-  "version": "1.1.6-beta.5",
+  "version": "1.1.6-beta.6",
   "description": "router module.",
   "keywords": [
     "garfish",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/utils",
-  "version": "1.1.6-beta.3",
+  "version": "1.1.6-beta.4",
   "description": "utils module.",
   "keywords": [
     "garfish",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/utils",
-  "version": "1.1.6-beta.1",
+  "version": "1.1.6-beta.3",
   "description": "utils module.",
   "keywords": [
     "garfish",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/utils",
-  "version": "1.1.6",
+  "version": "1.1.6-beta.7",
   "description": "utils module.",
   "keywords": [
     "garfish",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@garfish/utils",
-<<<<<<< HEAD
-  "version": "1.1.6-beta.6",
-=======
   "version": "1.1.6",
->>>>>>> master
   "description": "utils module.",
   "keywords": [
     "garfish",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/utils",
-  "version": "1.1.5",
+  "version": "1.1.6-beta.1",
   "description": "utils module.",
   "keywords": [
     "garfish",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/utils",
-  "version": "1.1.6-beta.4",
+  "version": "1.1.6-beta.5",
   "description": "utils module.",
   "keywords": [
     "garfish",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/utils",
-  "version": "1.1.6-beta.5",
+  "version": "1.1.6-beta.6",
   "description": "utils module.",
   "keywords": [
     "garfish",

--- a/packages/utils/src/utils.ts
+++ b/packages/utils/src/utils.ts
@@ -493,10 +493,12 @@ export function safari13Deal() {
     // Object.defineProperty is used to implement, so defineProperty is triggered when set is triggered
     // but the descriptor values ​​writable, enumerable, and configurable on safari 13.x version are set to false for the second time
     handleDescriptor(descriptor: PropertyDescriptor) {
-      fromSetFlag = false;
-      if (descriptor?.writable === false) descriptor.writable = true;
-      if (descriptor?.enumerable === false) descriptor.writable = true;
-      if (descriptor?.configurable === false) descriptor.configurable = true;
+      if ((fromSetFlag = true)) {
+        fromSetFlag = false;
+        if (descriptor?.writable === false) descriptor.writable = true;
+        if (descriptor?.enumerable === false) descriptor.writable = true;
+        if (descriptor?.configurable === false) descriptor.configurable = true;
+      }
     },
   };
 }

--- a/packages/utils/src/utils.ts
+++ b/packages/utils/src/utils.ts
@@ -476,3 +476,27 @@ export function getGarfishDebugInstanceName(): string | null {
     getParameterByName(DEBUG_GARFISH_TAG)
   );
 }
+
+// Reflect.set will be called in the set callback, and the DefineProperty callback will be triggered after Reflect.set is called.
+// but the descriptor values ​​writable, enumerable, and configurable on safari 13.x version are set to false for the second time
+// set and defineProperty callback is async Synchronize back
+// Set the default when calling defineProperty through set ​​writable, enumerable, and configurable default to true
+// safari 13.x default use strict mode，descriptor's ​​writable is false can't set again
+// deal safari 13
+export function safari13Deal() {
+  let fromSetFlag = false;
+  return {
+    triggerSet() {
+      fromSetFlag = true;
+    },
+    // reason: Reflect.set
+    // Object.defineProperty is used to implement, so defineProperty is triggered when set is triggered
+    // but the descriptor values ​​writable, enumerable, and configurable on safari 13.x version are set to false for the second time
+    handleDescriptor(descriptor: PropertyDescriptor) {
+      fromSetFlag = false;
+      if (descriptor?.writable === false) descriptor.writable = true;
+      if (descriptor?.enumerable === false) descriptor.writable = true;
+      if (descriptor?.configurable === false) descriptor.configurable = true;
+    },
+  };
+}

--- a/packages/web-component/package.json
+++ b/packages/web-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/web-component",
-  "version": "1.1.6",
+  "version": "1.1.6-beta.7",
   "description": "garfish module.",
   "keywords": [
     "garfish",

--- a/packages/web-component/package.json
+++ b/packages/web-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/web-component",
-  "version": "1.1.6-beta.1",
+  "version": "1.1.6-beta.3",
   "description": "garfish module.",
   "keywords": [
     "garfish",

--- a/packages/web-component/package.json
+++ b/packages/web-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/web-component",
-  "version": "1.1.6-beta.4",
+  "version": "1.1.6-beta.5",
   "description": "garfish module.",
   "keywords": [
     "garfish",

--- a/packages/web-component/package.json
+++ b/packages/web-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/web-component",
-  "version": "1.1.5",
+  "version": "1.1.6-beta.1",
   "description": "garfish module.",
   "keywords": [
     "garfish",

--- a/packages/web-component/package.json
+++ b/packages/web-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/web-component",
-  "version": "1.1.6-beta.3",
+  "version": "1.1.6-beta.4",
   "description": "garfish module.",
   "keywords": [
     "garfish",

--- a/packages/web-component/package.json
+++ b/packages/web-component/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@garfish/web-component",
-<<<<<<< HEAD
-  "version": "1.1.6-beta.6",
-=======
   "version": "1.1.6",
->>>>>>> master
   "description": "garfish module.",
   "keywords": [
     "garfish",

--- a/packages/web-component/package.json
+++ b/packages/web-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/web-component",
-  "version": "1.1.6-beta.5",
+  "version": "1.1.6-beta.6",
   "description": "garfish module.",
   "keywords": [
     "garfish",


### PR DESCRIPTION
## bugs
* function.prototype.toString may be isn't function in a lower version browser
* onselectstart、ondragstart can't set to proxy document
* vmsandbox：can't clear side effect sync，child app unmout maybe in macro task
* safari 13.x（Proxy object's 'set' trap returned falsy value for property）
     * Reflect.set will be called in the set callback, and the DefineProperty callback will be triggered after Reflect.set is called.
     * but the descriptor values ​​writable, enumerable, and configurable on safari 13.x version are set to false for the second time
     * Set the default when calling defineProperty through set ​​writable, enumerable, and configurable default to true
     * safari 13.x default use strict mode，descriptor's ​​writable is false can't set again


