### PR TITLE
feat: support cross origin script with 'use-credentials' flag

### DIFF
--- a/packages/browser-vm/src/dynamicNode/processor.ts
+++ b/packages/browser-vm/src/dynamicNode/processor.ts
@@ -120,7 +120,7 @@ export class DynamicNodeProcessor {
 
   // Load dynamic js script
   private addDynamicScriptNode() {
-    const { src, type } = this.el;
+    const { src, type, crossOrigin } = this.el;
     const isModule = type === 'module';
     const mimeType = parseContentType(type);
     const code = this.el.textContent || this.el.text || '';
@@ -130,23 +130,25 @@ export class DynamicNodeProcessor {
       const { baseUrl, namespace = '' } = this.sandbox.options;
       if (src) {
         const fetchUrl = baseUrl ? transformUrl(baseUrl, src) : src;
-        this.sandbox.loader.load<JavaScriptManager>(namespace, fetchUrl).then(
-          ({ resourceManager: { url, scriptCode } }) => {
-            // It is necessary to ensure that the code execution error cannot trigger the `el.onerror` event
-            this.sandbox.execScript(scriptCode, {}, url, {
-              isModule,
-              noEntry: true,
-            });
-            this.dispatchEvent('load');
-          },
-          (e) => {
-            __DEV__ && warn(e);
-            this.dispatchEvent('error', {
-              error: e,
-              filename: fetchUrl,
-            });
-          },
-        );
+        this.sandbox.loader
+          .load<JavaScriptManager>(namespace, fetchUrl, undefined, crossOrigin)
+          .then(
+            ({ resourceManager: { url, scriptCode } }) => {
+              // It is necessary to ensure that the code execution error cannot trigger the `el.onerror` event
+              this.sandbox.execScript(scriptCode, {}, url, {
+                isModule,
+                noEntry: true,
+              });
+              this.dispatchEvent('load');
+            },
+            (e) => {
+              __DEV__ && warn(e);
+              this.dispatchEvent('error', {
+                error: e,
+                filename: fetchUrl,
+              });
+            },
+          );
       } else if (code) {
         this.sandbox.execScript(code, {}, baseUrl, { noEntry: true });
       }

--- a/packages/core/src/module/resource.ts
+++ b/packages/core/src/module/resource.ts
@@ -22,6 +22,10 @@ function fetchStaticResources(
       .map((node) => {
         const src = entryManager.findAttributeValue(node, 'src');
         const type = entryManager.findAttributeValue(node, 'type');
+        const crossOrigin = entryManager.findAttributeValue(
+          node,
+          'crossorigin',
+        );
 
         // There should be no embedded script in the script element tag with the src attribute specified
         if (src) {
@@ -31,7 +35,12 @@ function fetchStaticResources(
           // Scripts with "async" attribute will make the rendering process very complicated,
           // we have a preload mechanism, so we don’t need to deal with it.
           return loader
-            .load<JavaScriptManager>(appName, fetchUrl)
+            .load<JavaScriptManager>(
+              appName,
+              fetchUrl,
+              undefined,
+              crossOrigin === 'use-credentials',
+            )
             .then(({ resourceManager: jsManager }) => {
               jsManager.setDep(node);
               jsManager.setMimeType(type);

--- a/packages/core/src/module/resource.ts
+++ b/packages/core/src/module/resource.ts
@@ -35,12 +35,7 @@ function fetchStaticResources(
           // Scripts with "async" attribute will make the rendering process very complicated,
           // we have a preload mechanism, so we don’t need to deal with it.
           return loader
-            .load<JavaScriptManager>(
-              appName,
-              fetchUrl,
-              undefined,
-              crossOrigin === 'use-credentials',
-            )
+            .load<JavaScriptManager>(appName, fetchUrl, undefined, crossOrigin)
             .then(({ resourceManager: jsManager }) => {
               jsManager.setDep(node);
               jsManager.setMimeType(type);

--- a/packages/loader/src/index.ts
+++ b/packages/loader/src/index.ts
@@ -98,6 +98,7 @@ export class Loader {
     scope: string,
     url: string,
     isModule = false,
+    isIncludeCredentials = false,
   ): Promise<LoadedHookArgs<T>['value']> {
     const { options, loadingList, cacheStore } = this;
 
@@ -130,6 +131,8 @@ export class Loader {
     }
 
     const requestConfig = mergeConfig(this, url);
+    // Tells browsers to include credentials in both same- and cross-origin requests, and always use any credentials sent back in responses.
+    requestConfig.credentials = isIncludeCredentials ? 'include' : undefined;
     const resOpts = this.hooks.lifecycle.beforeLoad.emit({
       url,
       requestConfig,

--- a/packages/loader/src/index.ts
+++ b/packages/loader/src/index.ts
@@ -43,6 +43,11 @@ export interface LoadedHookArgs<T extends Manager> {
   value: CacheValue<T>;
 }
 
+export enum CrossOriginCredentials {
+  anonymous = 'same-origin',
+  'use-credentials' = 'include',
+}
+
 export class Loader {
   public personalId = __LOADER_FLAG__;
   public StyleManager = StyleManager;
@@ -98,7 +103,7 @@ export class Loader {
     scope: string,
     url: string,
     isModule = false,
-    isIncludeCredentials = false,
+    crossOrigin: HTMLScriptElement['crossOrigin'] = 'anonymous',
   ): Promise<LoadedHookArgs<T>['value']> {
     const { options, loadingList, cacheStore } = this;
 
@@ -132,7 +137,7 @@ export class Loader {
 
     const requestConfig = mergeConfig(this, url);
     // Tells browsers to include credentials in both same- and cross-origin requests, and always use any credentials sent back in responses.
-    requestConfig.credentials = isIncludeCredentials ? 'include' : undefined;
+    requestConfig.credentials = CrossOriginCredentials[crossOrigin];
     const resOpts = this.hooks.lifecycle.beforeLoad.emit({
       url,
       requestConfig,


### PR DESCRIPTION
类似`<script crossorigin="use-credentials" src="xxx.js"></script>`这种带有`use-credentials`跨域标记的，请求时应该要允许携带cookie。