### PR TITLE
feat(core): assertion app entry After the beforeLoad hook is called

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -21,8 +21,7 @@ module.exports = {
   ],
   transform: { '\\.js$': ['babel-jest'], '\\.ts$': 'ts-jest' },
   rootDir: __dirname,
-  // testMatch: ['<rootDir>/packages/**/__tests__/**/*spec.[jt]s?(x)'],
-  testMatch: ['<rootDir>/packages/core/__tests__/loadApp.spec.ts'],
+  testMatch: ['<rootDir>/packages/**/__tests__/**/*spec.[jt]s?(x)'],
   testPathIgnorePatterns: ['/node_modules/', '/dev/'],
   moduleNameMapper: {
     '@garfish/(.*)': '<rootDir>packages/$1/src',

--- a/packages/core/__tests__/loadApp.spec.ts
+++ b/packages/core/__tests__/loadApp.spec.ts
@@ -1,4 +1,3 @@
-import { Options } from './../../router/src/config';
 import {
   __MockBody__,
   __MockHead__,

--- a/packages/core/__tests__/loadApp.spec.ts
+++ b/packages/core/__tests__/loadApp.spec.ts
@@ -130,7 +130,19 @@ describe('Core: load process', () => {
     });
   });
 
-  it('throws an error when entry is not provided after beforeLoad', async () => {
+  it('throws an error when entry option is not provided', async () => {
+    let isError = false;
+    try {
+      await GarfishInstance.loadApp('vue-app', {
+        domGetter: '#container',
+      });
+    } catch (error) {
+      isError = true;
+    }
+    expect(isError).toBe(true);
+  });
+
+  it('check the error message when entry is not provided after beforeLoad', async () => {
     await expect(
       GarfishInstance.loadApp('vue-app', {
         domGetter: '#container',

--- a/packages/core/__tests__/loadApp.spec.ts
+++ b/packages/core/__tests__/loadApp.spec.ts
@@ -130,18 +130,6 @@ describe('Core: load process', () => {
     });
   });
 
-  it('throws an error when entry option is not provided', async () => {
-    let isError = false;
-    try {
-      await GarfishInstance.loadApp('vue-app', {
-        domGetter: '#container',
-      });
-    } catch (error) {
-      isError = true;
-    }
-    expect(isError).toBe(true);
-  });
-
   it('check the error message when entry is not provided after beforeLoad', async () => {
     await expect(
       GarfishInstance.loadApp('vue-app', {

--- a/packages/core/__tests__/loadApp.spec.ts
+++ b/packages/core/__tests__/loadApp.spec.ts
@@ -1,3 +1,4 @@
+import { Options } from './../../router/src/config';
 import {
   __MockBody__,
   __MockHead__,
@@ -115,5 +116,54 @@ describe('Core: load process', () => {
       0,
     );
     document.body.removeChild(container);
+  });
+
+  it('not throws an error when entry option is provided', async () => {
+    let isError = false;
+    try {
+      await GarfishInstance.loadApp('vue-app', {
+        domGetter: '#container',
+        entry: vueSubAppEntry,
+      });
+    } catch {
+      isError = true;
+    }
+    expect(isError).toBe(false);
+  });
+
+  it('throws an error when entry option is not provided after beforeLoad', async () => {
+    let isError = false;
+    try {
+      await GarfishInstance.loadApp('vue-app', {
+        domGetter: '#container',
+      });
+    } catch {
+      isError = true;
+    }
+    expect(isError).toBe(true);
+  });
+
+  it('not throws an error when entry option is provided after beforeLoad', async () => {
+    let isError = false;
+
+    const mockBeforeLoad = jest.fn(() => {
+      GarfishInstance.appInfos['vue-app'] = {
+        name: 'vue-app',
+        entry: vueSubAppEntry,
+      };
+    });
+
+    GarfishInstance.run({
+      beforeLoad: mockBeforeLoad,
+    });
+
+    try {
+      await GarfishInstance.loadApp('vue-app', {
+        domGetter: '#container',
+      });
+    } catch {
+      isError = true;
+    }
+    expect(isError).toBe(false);
   });
 });

--- a/packages/core/__tests__/loadApp.spec.ts
+++ b/packages/core/__tests__/loadApp.spec.ts
@@ -118,33 +118,29 @@ describe('Core: load process', () => {
   });
 
   it('not throws an error when entry option is provided', async () => {
-    let isError = false;
-    try {
-      await GarfishInstance.loadApp('vue-app', {
+    await expect(
+      GarfishInstance.loadApp('vue-app', {
         domGetter: '#container',
         entry: vueSubAppEntry,
-      });
-    } catch {
-      isError = true;
-    }
-    expect(isError).toBe(false);
+      }),
+    ).resolves.toMatchObject({
+      appInfo: {
+        entry: vueSubAppEntry,
+      },
+    });
   });
 
-  it('throws an error when entry option is not provided after beforeLoad', async () => {
-    let isError = false;
-    try {
-      await GarfishInstance.loadApp('vue-app', {
+  it('throws an error when entry is not provided after beforeLoad', async () => {
+    await expect(
+      GarfishInstance.loadApp('vue-app', {
         domGetter: '#container',
-      });
-    } catch {
-      isError = true;
-    }
-    expect(isError).toBe(true);
+      }),
+    ).rejects.toThrow(
+      'Please provide the entry parameters or registered in advance of the app.',
+    );
   });
 
-  it('not throws an error when entry option is provided after beforeLoad', async () => {
-    let isError = false;
-
+  it('not throws an error when entry is provided after beforeLoad', async () => {
     const mockBeforeLoad = jest.fn(() => {
       GarfishInstance.appInfos['vue-app'] = {
         name: 'vue-app',
@@ -156,13 +152,14 @@ describe('Core: load process', () => {
       beforeLoad: mockBeforeLoad,
     });
 
-    try {
-      await GarfishInstance.loadApp('vue-app', {
+    await expect(
+      GarfishInstance.loadApp('vue-app', {
         domGetter: '#container',
-      });
-    } catch {
-      isError = true;
-    }
-    expect(isError).toBe(false);
+      }),
+    ).resolves.toMatchObject({
+      appInfo: {
+        entry: vueSubAppEntry,
+      },
+    });
   });
 });

--- a/packages/core/__tests__/vue3App.html
+++ b/packages/core/__tests__/vue3App.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>vue3 sub app</title>
+    <title>vue sub app</title>
   </head>
   <body>
     <div id="app"></div>
@@ -11,12 +11,12 @@
           return {
             render ({ dom , basename }) {
               let newContent = document.createElement('div');
-              newContent.setAttribute('id', 'hello-world');
+              newContent.setAttribute('id', 'hello-world-vue3');
               dom.querySelector('#app').appendChild(newContent);
             },
 
             destroy ({ dom , basename }){
-              dom.querySelector('#app').removeChild(dom.querySelector('#hello-world'));
+              dom.querySelector('#app').removeChild(dom.querySelector('#hello-world-vue3'));
             }
           }
         }

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -89,11 +89,6 @@ export const generateAppOptions = (
   appInfo = getAppConfig(garfish.options, appInfo || {});
   appInfo.name = appName;
 
-  assert(
-    appInfo.entry,
-    `Can't load unexpected child app "${appName}", ` +
-      'Please provide the entry parameters or registered in advance of the app.',
-  );
   return appInfo;
 };
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -63,22 +63,6 @@ export const generateAppOptions = (
   appOptionsOrUrl?: Omit<interfaces.AppInfo, 'name'>,
 ): AppInfo => {
   let appInfo = garfish.appInfos[appName];
-  // Load the unregistered applications
-  // `Garfish.loadApp('appName', 'https://xx.html');`
-  // if (typeof appOptionsOrUrl === 'string') {
-  //   if (appInfo) {
-  //     appInfo = {
-  //       ...appInfo,
-  //       entry: appOptionsOrUrl,
-  //     };
-  //   } else {
-  //     appInfo = {
-  //       name: appName,
-  //       basename: '/',
-  //       entry: appOptionsOrUrl,
-  //     };
-  //   }
-  // }
 
   // Merge register appInfo config and loadApp config
   if (isObject(appOptionsOrUrl)) {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -11,21 +11,40 @@ import { AppInfo } from './module/app';
 import { interfaces } from './interface';
 import { appLifecycle } from './lifecycle';
 
-// TODO: Infer the contents and check
-const appConfigList: Array<keyof interfaces.AppInfo | 'activeWhen'> = [
-  'name',
-  'entry',
-  'activeWhen',
-  'basename',
-  'domGetter',
-  'props',
-  'sandbox',
-  'cache',
-  'noCheckProvider',
-  'protectVariable',
-  'customLoader',
-  ...appLifecycle().lifecycleKeys,
-];
+const appConfigKeysMap: {
+  [k in keyof interfaces.AppInfo | 'activeWhen']: boolean;
+} = {
+  // subApp info return keys
+  name: true,
+  entry: true,
+  activeWhen: true,
+  basename: true,
+  domGetter: true,
+  props: true,
+  sandbox: true,
+  cache: true,
+  noCheckProvider: true,
+  protectVariable: true,
+  customLoader: true,
+
+  // appLifecycle keys
+  beforeEval: true,
+  afterEval: true,
+  beforeMount: true,
+  afterMount: true,
+  errorMountApp: true,
+  beforeUnmount: true,
+  afterUnmount: true,
+  errorUnmountApp: true,
+  errorExecCode: true,
+
+  // filter keys
+  nested: false,
+  insulationVariable: false,
+  active: false,
+  deactive: false,
+  rootPath: false,
+};
 
 // `props` may be responsive data
 export const deepMergeConfig = <T extends Partial<AppInfo>>(
@@ -55,10 +74,7 @@ export const getAppConfig = <T extends Partial<AppInfo>>(
   const mergeConfig = deepMergeConfig(globalConfig, localConfig);
 
   Object.keys(mergeConfig).forEach((key) => {
-    if (
-      !appConfigList.includes(key as any) ||
-      typeof mergeConfig[key] === 'undefined'
-    ) {
+    if (!appConfigKeysMap[key] || typeof mergeConfig[key] === 'undefined') {
       delete mergeConfig[key];
     }
   });

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -60,25 +60,25 @@ export const getAppConfig = <T>(globalConfig, localConfig) => {
 export const generateAppOptions = (
   appName: string,
   garfish: interfaces.Garfish,
-  appOptionsOrUrl: Partial<interfaces.AppInfo> | string = {},
+  appOptionsOrUrl?: Omit<interfaces.AppInfo, 'name'>,
 ): AppInfo => {
   let appInfo = garfish.appInfos[appName];
   // Load the unregistered applications
   // `Garfish.loadApp('appName', 'https://xx.html');`
-  if (typeof appOptionsOrUrl === 'string') {
-    if (appInfo) {
-      appInfo = {
-        ...appInfo,
-        entry: appOptionsOrUrl,
-      };
-    } else {
-      appInfo = {
-        name: appName,
-        basename: '/',
-        entry: appOptionsOrUrl,
-      };
-    }
-  }
+  // if (typeof appOptionsOrUrl === 'string') {
+  //   if (appInfo) {
+  //     appInfo = {
+  //       ...appInfo,
+  //       entry: appOptionsOrUrl,
+  //     };
+  //   } else {
+  //     appInfo = {
+  //       name: appName,
+  //       basename: '/',
+  //       entry: appOptionsOrUrl,
+  //     };
+  //   }
+  // }
 
   // Merge register appInfo config and loadApp config
   if (isObject(appOptionsOrUrl)) {

--- a/packages/core/src/garfish.ts
+++ b/packages/core/src/garfish.ts
@@ -170,7 +170,7 @@ export class Garfish extends EventEmitter2 {
         return null;
       }
 
-      // merge configs again after beforeLoad
+      //merge configs again after beforeLoad for the reason of app may be re-registered during beforeLoad resulting in an incorrect information
       appInfo = generateAppOptions(appName, this, options);
 
       assert(

--- a/packages/core/src/garfish.ts
+++ b/packages/core/src/garfish.ts
@@ -164,13 +164,16 @@ export class Garfish extends EventEmitter2 {
       // Return not undefined type data directly to end loading
       const stop = await this.hooks.lifecycle.beforeLoad.emit(appInfo);
 
-      if (!optionsOrUrl?.entry) {
-        assert(
-          this.appInfos[appName]?.entry,
-          `Can't load unexpected child app "${appName}", ` +
-            'Please provide the entry parameters or registered in advance of the app.',
-        );
+      // if appInfo.entry is null, get app entry again from appInfos after beforeLoad
+      if (!appInfo.entry) {
+        appInfo.entry = this.appInfos[appName]?.entry;
       }
+
+      assert(
+        appInfo.entry,
+        `Can't load unexpected child app "${appName}", ` +
+          'Please provide the entry parameters or registered in advance of the app.',
+      );
 
       if (stop === false) {
         warn(`Load ${appName} application is terminated by beforeLoad.`);

--- a/packages/core/src/garfish.ts
+++ b/packages/core/src/garfish.ts
@@ -163,6 +163,13 @@ export class Garfish extends EventEmitter2 {
     const asyncLoadProcess = async () => {
       // Return not undefined type data directly to end loading
       const stop = await this.hooks.lifecycle.beforeLoad.emit(appInfo);
+
+      assert(
+        this.appInfos[appName].entry,
+        `Can't load unexpected child app "${appName}", ` +
+          'Please provide the entry parameters or registered in advance of the app.',
+      );
+
       if (stop === false) {
         warn(`Load ${appName} application is terminated by beforeLoad.`);
         return null;

--- a/packages/core/src/garfish.ts
+++ b/packages/core/src/garfish.ts
@@ -164,11 +164,13 @@ export class Garfish extends EventEmitter2 {
       // Return not undefined type data directly to end loading
       const stop = await this.hooks.lifecycle.beforeLoad.emit(appInfo);
 
-      assert(
-        this.appInfos[appName].entry,
-        `Can't load unexpected child app "${appName}", ` +
-          'Please provide the entry parameters or registered in advance of the app.',
-      );
+      if (!optionsOrUrl?.entry) {
+        assert(
+          this.appInfos[appName]?.entry,
+          `Can't load unexpected child app "${appName}", ` +
+            'Please provide the entry parameters or registered in advance of the app.',
+        );
+      }
 
       if (stop === false) {
         warn(`Load ${appName} application is terminated by beforeLoad.`);


### PR DESCRIPTION
# PR Details
assert app entry after beforeLoad hook

## Description
assertion app entry  After the beforeLoad hook is called

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
application may be re-registered during beforeLoad, resulting in inaccurate information. so It is necessary to put off the assertion judgment of app entry  after beforeLoad is called to  ensure that the final application information is obtained. And after that we can make the assertion judgment of the app entry.

For example, for the scenario of using the get-app-list plugin, we need that feature.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
