### PR TITLE
refactor(vm-sandbox): reset app side effect in micro task

### DIFF
--- a/packages/browser-vm/src/pluginify.ts
+++ b/packages/browser-vm/src/pluginify.ts
@@ -1,5 +1,5 @@
 import { interfaces } from '@garfish/core';
-import { warn, isPlainObject } from '@garfish/utils';
+import { warn, isPlainObject, nextTick } from '@garfish/utils';
 import { Module } from './types';
 import { Sandbox } from './sandbox';
 import { recordStyledComponentCSSRules, rebuildCSSRules } from './dynamicNode';
@@ -153,7 +153,9 @@ function createOptions(Garfish: interfaces.Garfish) {
     afterUnmount(appInfo, appInstance, isCacheMode) {
       // The caching pattern to retain the same context
       if (appInstance.vmSandbox && !isCacheMode) {
-        appInstance.vmSandbox.reset();
+        nextTick(() => {
+          appInstance.vmSandbox.reset();
+        });
       }
     },
 


### PR DESCRIPTION
# PR Details

refactor(vm-sandbox): reset app side effect in micro task

## Description


## Motivation and Context

After the sub-application triggers the destruction function, the content of some destruction side effects is placed in the microtask, which causes the destruction to fail. It is necessary to ensure that the destruction side effect is after other tasks of the sub-application.

## How Has This Been Tested

* micro task clear sub app side effect，make sure it's clean

## Types of changes


- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
