### PR TITLE
fix(browser-vm): Babel cannot correctly identify the MutationObserver in the code as a native class, resulting in the error that MutationObserver must use the new operator after compilation

### DIFF
--- a/packages/browser-vm/src/modules/mutationObserver.ts
+++ b/packages/browser-vm/src/modules/mutationObserver.ts
@@ -1,11 +1,9 @@
 import { Sandbox } from '../sandbox';
 
-const rawMutationObserver = window.MutationObserver;
-
 export function observerModule(_sandbox: Sandbox) {
   const observerSet = new Set<MutationObserver>();
 
-  class MutationObserver extends rawMutationObserver {
+  class ProxyMutationObserver extends MutationObserver {
     constructor(cb: MutationCallback) {
       super(cb);
       observerSet.add(this);
@@ -22,7 +20,7 @@ export function observerModule(_sandbox: Sandbox) {
   return {
     recover,
     override: {
-      MutationObserver: MutationObserver as Function,
+      MutationObserver: ProxyMutationObserver as Function,
     },
   };
 }


### PR DESCRIPTION


## Description

fix(browser-vm): Babel cannot correctly identify the MutationObserver in the code as a native class, resulting in the error that MutationObserver must use the new operator after compilation

## Related Issue

#450 

## Motivation and Context

* fixed #450

## How Has This Been Tested

* no tests need to be added

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
