### PR TITLE
fix(loader): support @charset removing and @import without url()

### DIFF
--- a/packages/loader/__tests__/styleProcess.spec.ts
+++ b/packages/loader/__tests__/styleProcess.spec.ts
@@ -1,0 +1,33 @@
+import { StyleManager } from '../src/managers/style';
+
+describe('Loader: style process', () => {
+  it('adjust @import to be with url()', () => {
+    const styleManager = new StyleManager(' @import   \'foo.css\' ; @import   "bar.css" ; ');
+
+    styleManager.correctPath('https://google.com');
+    // "@import" without url() is legal, adjust it to be more simple to corrent paths.
+    expect(styleManager.styleCode).toContain('url("https://google.com/foo.css")');
+    expect(styleManager.styleCode).toContain('url("https://google.com/bar.css")');
+  });
+
+  it('support external url with parentheses', () => {
+    const styleManager = new StyleManager('.foo { background: url("/foo(1).png") }');
+    styleManager.correctPath('https://google.com');
+    // File names with parentheses are allowed.
+    expect(styleManager.styleCode).toContain('url("https://google.com/foo(1).png")')
+  });
+
+  it('do not support external url with asymmetrical quotation marks', () => {
+    const styleManager = new StyleManager('.foo { background: url("foo.png\') }');
+    styleManager.correctPath('https://google.com');
+    // Asymmetrical quotation marks lead to syntax error
+    expect(styleManager.styleCode).not.toContain('url("https://google.com/foo(1).png")')
+  });
+
+  it('remove all @charset', () => {
+    const styleManager = new StyleManager(' @charset  \'UTF-8\' ;  @charset "utf8"; ');
+    styleManager.correctPath('https://google.com');
+    // "@charset" is pointless for inline styles
+    expect(styleManager.styleCode.trim()).toHaveLength(0);
+  });
+});

--- a/packages/loader/src/managers/style.ts
+++ b/packages/loader/src/managers/style.ts
@@ -1,7 +1,9 @@
 import { Node, isAbsolute, transformUrl } from '@garfish/utils';
 
 // Match url in css
-const MATCH_CSS_URL = /url\(['"]?([^\)]+?)['"]?\)/g;
+const MATCH_CSS_URL = /url\(\s*(['"])?(.*?)\1\s*\)/g;
+const MATCH_CHARSET_URL = /@charset\s+(['"])(.*?)\1\s*;?/g;
+const MATCH_IMPORT_URL = /@import\s+(['"])(.*?)\1/g;
 
 export class StyleManager {
   public url: string | null;
@@ -19,8 +21,12 @@ export class StyleManager {
     if (!baseUrl) baseUrl = url;
     if (baseUrl && typeof styleCode === 'string') {
       // The relative path is converted to an absolute path according to the path of the css file
-      this.styleCode = styleCode.replace(MATCH_CSS_URL, (k1, k2) => {
-        if (isAbsolute(k2)) return k1;
+      this.styleCode = styleCode.replace(MATCH_CHARSET_URL, '')
+        .replace(MATCH_IMPORT_URL, function (k0, k1, k2) {
+          return k2 ? `@import url(${k1}${k2}${k1})` : k0;
+        })
+      .replace(MATCH_CSS_URL, (k0, k1, k2) => {
+        if (isAbsolute(k2)) return k0;
         return `url("${transformUrl(baseUrl, k2)}")`;
       });
     }


### PR DESCRIPTION
# PR Details

- [x] 支持无url()的@import语句
- [x] 移除@charset语句
- [x] 更新了匹配url()的正则  

## Description

1. 将无url()的@import语句转换为有url()，以供后续统一处理；
2. @charset在&lt;style&gt;无意义，直接移除；
3. url()可匹配带文件名带括号的资源

## Related Issue

<https://github.com/modern-js-dev/garfish/issues/446>

## Motivation and Context

1. 支持了无url()的@import语句，兼容性更好
2. 顺带移除了可能出现的@charset语句，减少控制台warning
3. 优化了url()匹配模式，能兼容更多合理的资源名

## How Has This Been Tested

repo中无相关test case，可手动在 <https://github.com/yanni4night/garfish-issue-reproduction/tree/issue-446> 验证。

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
