### PR TITLE
fix(vm-sandbox): Babel cannot correctly identify the MouseEvent  in the code as a native class

### DIFF
--- a/packages/browser-vm/src/modules/uiEvent.ts
+++ b/packages/browser-vm/src/modules/uiEvent.ts
@@ -3,9 +3,7 @@ import { getType } from '@garfish/utils';
 // The logic of UIEvent is referenced from qiankun typography
 // https://github.com/umijs/qiankun/pull/593/files
 // TODO: fix normal mouse event instanceof MouseEvent === false
-
-const RawMouseEvent = window.MouseEvent;
-export class MouseEventPatch extends RawMouseEvent {
+export class MouseEventPatch extends MouseEvent {
   constructor(typeArg: string, mouseEventInit?: MouseEventInit) {
     if (mouseEventInit && getType(mouseEventInit.view) === 'window') {
       mouseEventInit.view = window;


### PR DESCRIPTION
fix(vm-sandbox): Babel cannot correctly identify the MouseEvent  in the code as a native class

# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

#450 

## Motivation and Context

* fixed #450

## How Has This Been Tested

* no tests need to be added

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
