### PR TITLE
fix(snapshot-sandbox): GarfishBrowserSnapshot plugin use global variables, causing sub app configurations to pollute each other fix issue #459

### DIFF
--- a/packages/browser-snapshot/src/index.ts
+++ b/packages/browser-snapshot/src/index.ts
@@ -17,14 +17,13 @@ interface BrowserConfig {
 
 export function GarfishBrowserSnapshot(op?: BrowserConfig) {
   return function (Garfish: interfaces.Garfish): interfaces.Plugin {
-    const config: BrowserConfig = op || { open: true };
-
     const options = {
       openBrowser: false,
       version: __VERSION__,
       name: 'browser-snapshot',
 
       afterLoad(appInfo, appInstance) {
+        const config: BrowserConfig = op || { open: true };
         const sandboxConfig = appInfo.sandbox || Garfish?.options?.sandbox;
         if (
           sandboxConfig === false ||


### PR DESCRIPTION
# PR Details
fix issue#459: GarfishBrowserSnapshot plugin use global variables, causing sub app configurations to pollute each other #459

## Description
GarfishBrowserSnapshot plugin use global variables, causing sub app configurations to pollute each other.

A variable is used in the GarfishBrowserSnapshot plugin to identify whether an application has enabled snapshot sandbox mode, but unfortunately, it is a global variable, which causes the sub-application to be loaded later to be polluted by the previous sub-application，affecting the initial state of the plugin.

For example, if the previous app closes the snapshot sandbox, the apps loaded later will also be judged to close the sandbox because the global variable has been marked as false, which will result in an application initialization error, as a result, the post-loaded sub-application snapshot sandbox is invalid.

## Related Issue
https://github.com/modern-js-dev/garfish/issues/459

## Motivation and Context
GarfishBrowserSnapshot plugin use global variables, causing sub app configurations to pollute each other . 

## How Has This Been Tested

- All tests passed.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
