### PR TITLE
fix(vm-sandbox): deferClearEffects memory leak

### DIFF
--- a/packages/browser-vm/__tests__/dom-side-effect.spec.ts
+++ b/packages/browser-vm/__tests__/dom-side-effect.spec.ts
@@ -85,7 +85,7 @@ describe('Sandbox:Dom & Bom', () => {
     const testNode = document.getElementById(testId);
     const test2Node = document.getElementById(testId);
 
-    expect(sandbox.deferClearEffects.size).toBe(2);
+    expect(sandbox.deferClearEffects.size).toBe(1);
     expect(testNode.contains(test2Node)).toBeTruthy();
     expect(rootNode.contains(testNode)).toBeTruthy();
     sandbox.close();

--- a/packages/browser-vm/__tests__/dom-side-effect.spec.ts
+++ b/packages/browser-vm/__tests__/dom-side-effect.spec.ts
@@ -1,0 +1,95 @@
+import { Sandbox } from '../src/sandbox';
+import { sandboxMap } from '../src/utils';
+import {
+  recordStyledComponentCSSRules,
+  rebuildCSSRules,
+} from '../src/dynamicNode';
+
+// Garfish 使用 Proxy 对 dom 进行了劫持, 同时对调用 dom 的函数做了劫持, 修正 dom 节点的类型
+// 对调用 dom 的相关方法进行测试
+describe('Sandbox:Dom & Bom', () => {
+  let sandbox: Sandbox;
+  window.dispatchEvent = () => true;
+
+  const go = (code: string) => {
+    return `
+      const sandbox = __debug_sandbox__;
+      const Sandbox = sandbox.constructor;
+      const nativeWindow = Sandbox.getNativeWindow();
+      document.body.innerHTML = '<div id="root">123</div><div __garfishmockhead__></div>'
+      ${code}
+    `;
+  };
+
+  const create = (opts = {}) => {
+    return new Sandbox({
+      ...opts,
+      namespace: 'app',
+      el: () => document.createElement('div'),
+      modules: [
+        () => ({
+          recover() {},
+          override: {
+            go,
+            jest,
+            expect,
+          },
+        }),
+      ],
+    });
+  };
+
+  beforeEach(() => {
+    sandbox = create();
+  });
+
+  it('clear dom side effect', () => {
+    const rootId = 'root';
+    const testId = 'test';
+    sandbox.execScript(
+      go(`
+        const root = document.getElementById('${rootId}');
+        const div = document.createElement('div');
+        const id = '${testId}';
+        div.id = id;
+        root.appendChild(div);
+      `),
+    );
+
+    const rootNode = document.getElementById(rootId);
+    const testNode = document.getElementById(testId);
+    expect(rootNode.contains(testNode)).toBeTruthy();
+    sandbox.close();
+
+    expect(rootNode.contains(testNode)).toBeFalsy();
+  });
+
+  it('dom side effect memory leak', () => {
+    const rootId = 'root';
+    const testId = 'test';
+    const test2Id = 'test2';
+    sandbox.execScript(
+      go(`
+        const root = document.getElementById('${rootId}');
+        const div = document.createElement('div');
+        div.id = '${testId}';
+        const div2 = document.createElement('div');
+        div2.id = '${test2Id}';
+
+        div.appendChild(div2);
+        root.appendChild(div);
+      `),
+    );
+
+    const rootNode = document.getElementById(rootId);
+    const testNode = document.getElementById(testId);
+    const test2Node = document.getElementById(testId);
+
+    expect(sandbox.deferClearEffects.size).toBe(2);
+    expect(testNode.contains(test2Node)).toBeTruthy();
+    expect(rootNode.contains(testNode)).toBeTruthy();
+    sandbox.close();
+
+    expect(rootNode.contains(testNode)).toBeFalsy();
+  });
+});

--- a/packages/browser-vm/src/dynamicNode/processor.ts
+++ b/packages/browser-vm/src/dynamicNode/processor.ts
@@ -274,6 +274,7 @@ export class DynamicNodeProcessor {
       if (parentNode !== this.rootElement) {
         this.sandbox.deferClearEffects.add(() => {
           this.DOMApis.removeElement(this.el);
+          return this.el;
         });
       }
     }

--- a/packages/browser-vm/src/dynamicNode/processor.ts
+++ b/packages/browser-vm/src/dynamicNode/processor.ts
@@ -267,7 +267,10 @@ export class DynamicNodeProcessor {
     }
 
     // Collect nodes that escape the container node
-    if (!this.rootElement.contains(parentNode)) {
+    if (
+      !this.rootElement.contains(parentNode) &&
+      document.contains(parentNode)
+    ) {
       if (parentNode !== this.rootElement) {
         this.sandbox.deferClearEffects.add(() => {
           this.DOMApis.removeElement(this.el);


### PR DESCRIPTION

## Description

* deferClearEffects memory leak

## Related Issue

#462 

## Motivation and Context

* After the vm sandbox is turned on, the vm sandbox will collect the dom nodes added to the document by the sub-application during rendering and running, to ensure that the nodes are also destroyed when the sub-application is uninstalled
* In order to avoid collecting nodes in the sub-application rendering container (nodes in the rendering container will be destroyed following the destruction of the root node)
* However, vue and react framework components will add nodes as a whole instead of part of them when rendering to improve performance, so that when nodes are not really added to the document flow, the !this.rootElement.contains(parentNode) judgment is always false


## How Has This Been Tested

[] need add

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
