### PR TITLE
feat(core): add app to activeApps in rendering

### DIFF
--- a/packages/core/__tests__/appInstance.spec.ts
+++ b/packages/core/__tests__/appInstance.spec.ts
@@ -1,0 +1,51 @@
+import {
+  __MockBody__,
+  __MockHead__,
+  __MockHtml__,
+  appContainerId,
+  mockStaticServer,
+} from '@garfish/utils';
+import Garfish from '../src/index';
+
+describe('Core: appInstance', () => {
+  let GarfishInstance: Garfish;
+  let container;
+
+  const vueSubAppEntry = './resources/vueApp.html';
+  const reactSubAppEntry = './resources/reactApp.html';
+  const vue3AppRenderNode = 'hello-world-vue3';
+  const vue3SubAppEntry = './resources/vue3App.html';
+  const asyncProviderApp = './resources/asyncProviderApp.html';
+
+  mockStaticServer(__dirname);
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    container.setAttribute('id', 'container');
+    document.body.appendChild(container);
+    GarfishInstance = new Garfish({});
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  it('mount activeApps', async () => {
+    const app = await GarfishInstance.loadApp('vue-app', {
+      entry: vueSubAppEntry,
+      domGetter: '#container',
+    });
+
+    await app.mount();
+    expect(GarfishInstance.activeApps[0]).toBe(app);
+
+    app.hide();
+    expect(GarfishInstance.activeApps[0]).toBeUndefined();
+
+    await app.show();
+    expect(GarfishInstance.activeApps[0]).toBe(app);
+
+    await app.unmount();
+    expect(GarfishInstance.activeApps[0]).toBeUndefined();
+  });
+});

--- a/packages/core/__tests__/loadApp.spec.ts
+++ b/packages/core/__tests__/loadApp.spec.ts
@@ -10,7 +10,7 @@ import Garfish from '../src/index';
 describe('Core: load process', () => {
   let GarfishInstance: Garfish;
   let container;
-  
+
   const vueSubAppEntry = './resources/vueApp.html';
   const reactSubAppEntry = './resources/reactApp.html';
   const vue3AppRenderNode = 'hello-world-vue3';

--- a/packages/core/src/module/app.ts
+++ b/packages/core/src/module/app.ts
@@ -234,9 +234,9 @@ export class App {
     this.hooks.lifecycle.beforeMount.emit(this.appInfo, this, true);
 
     await this.addContainer();
+    this.context.activeApps.push(this);
     this.callRender(provider, false);
     this.display = true;
-    this.context.activeApps.push(this);
     this.hooks.lifecycle.afterMount.emit(this.appInfo, this, true);
     return true;
   }
@@ -275,10 +275,10 @@ export class App {
       // Existing asynchronous functions need to decide whether the application has been unloaded
       if (!this.stopMountAndClearEffect()) return false;
 
+      this.context.activeApps.push(this);
       this.callRender(provider, true);
       this.display = true;
       this.mounted = true;
-      this.context.activeApps.push(this);
       this.hooks.lifecycle.afterMount.emit(this.appInfo, this, false);
 
       await asyncScripts;


### PR DESCRIPTION
# PR Details

feat(core): can get activeApps before rendering


## Motivation and Context

* some plugin need get the current app instance before rendering function call

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
