### PR TITLE
refactor(core): Add an app instance to activeApps before rendering

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,13 @@ const NodeGlobals = ['module', 'require'];
 module.exports = {
   root: true,
   parser: '@typescript-eslint/parser',
-  ignorePatterns: ['**/dist', 'dev/', 'api-extractor.json', 'packages/*/dist'],
+  ignorePatterns: [
+    '**/dist',
+    'dev/',
+    'shimsVue.d.ts',
+    'api-extractor.json',
+    'packages/*/dist',
+  ],
   parserOptions: {
     sourceType: 'module',
   },

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,6 @@
-# PR Details
-
-<!--- Provide a general summary of your changes in the Title above -->
-
 ## Description
 
+<!--- Provide a general summary of your changes in the Title above -->
 <!--- Describe your changes in detail -->
 
 ## Related Issue

--- a/dev/app-vue-2/src/shims-vue.d.ts
+++ b/dev/app-vue-2/src/shims-vue.d.ts
@@ -1,4 +1,0 @@
-declare module "*.vue" {
-	import Vue from "vue";
-	export default Vue;
-}

--- a/dev/app-vue-2/src/shimsVue.d.ts
+++ b/dev/app-vue-2/src/shimsVue.d.ts
@@ -1,0 +1,8 @@
+/* eslint-disable */
+declare module '*.vue' {
+  /* eslint-disable */
+  // eslint-disable-next-line
+  import type Vue from 'vue';
+  // eslint-disable-next-line
+  export default Vue;
+}

--- a/dev/app-vue-3/src/shims-vue.d.ts
+++ b/dev/app-vue-3/src/shims-vue.d.ts
@@ -1,5 +1,0 @@
-declare module "*.vue" {
-	import type { DefineComponent } from "vue";
-	const component: DefineComponent<{}, {}, any>;
-	export default component;
-}

--- a/dev/app-vue-3/src/shimsVue.d.ts
+++ b/dev/app-vue-3/src/shimsVue.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 declare module '*.vue' {
   import type { DefineComponent } from 'vue';
   const component: DefineComponent<{}, {}, any>;

--- a/dev/app-vue-vite/src/shimsVue.d.ts
+++ b/dev/app-vue-vite/src/shimsVue.d.ts
@@ -1,0 +1,6 @@
+/* eslint-disable */
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue';
+  const component: DefineComponent<{}, {}, any>;
+  export default component;
+}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
       "prettier --write"
     ],
     "*.ts?(x)": [
-      "eslint --fix",
+      "eslint --fix --config .eslintrc.js",
       "prettier --parser=typescript --write"
     ],
     "*.md": [

--- a/packages/core/src/module/app.ts
+++ b/packages/core/src/module/app.ts
@@ -232,9 +232,9 @@ export class App {
       return false;
     }
     this.hooks.lifecycle.beforeMount.emit(this.appInfo, this, true);
+    this.context.activeApps.push(this);
 
     await this.addContainer();
-    this.context.activeApps.push(this);
     this.callRender(provider, false);
     this.display = true;
     this.hooks.lifecycle.afterMount.emit(this.appInfo, this, true);
@@ -266,6 +266,7 @@ export class App {
     this.active = true;
     this.mounting = true;
     try {
+      this.context.activeApps.push(this);
       // add container and compile js with cjs
       const { asyncScripts } = await this.compileAndRenderContainer();
       if (!this.stopMountAndClearEffect()) return false;
@@ -275,7 +276,6 @@ export class App {
       // Existing asynchronous functions need to decide whether the application has been unloaded
       if (!this.stopMountAndClearEffect()) return false;
 
-      this.context.activeApps.push(this);
       this.callRender(provider, true);
       this.display = true;
       this.mounted = true;


### PR DESCRIPTION
# PR Details

refactor(core): Add an app instance to activeApps before rendering

## Motivation and Context

* can get activeApps when app start mount

## How Has This Been Tested

* don't need add test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
