### PR TITLE
fix(core): loadApp add default appInfo

### DIFF
--- a/packages/core/__tests__/loadApp.spec.ts
+++ b/packages/core/__tests__/loadApp.spec.ts
@@ -328,4 +328,51 @@ describe('Core: load process', () => {
 
     expect(document.body.contains(container)).toBe(true);
   });
+
+  it('loadApp before registered, the `beforeLoad` hook will not receive the undefined app.', async () => {
+    const mockBeforeLoad = jest.fn();
+
+    GarfishInstance.run({
+      domGetter: '#container',
+      apps: [
+        {
+          name: 'react',
+          entry: reactSubAppEntry,
+        },
+      ],
+      beforeLoad: mockBeforeLoad,
+    });
+
+    const testName = 'react-unexisted';
+    expect(GarfishInstance.appInfos[testName]).toBeUndefined;
+
+    await GarfishInstance.loadApp(testName, {
+      entry: reactSubAppEntry,
+    });
+
+    expect(mockBeforeLoad).toBeCalled();
+    expect(mockBeforeLoad.mock.calls[0][0]).not.toBeUndefined;
+    expect(mockBeforeLoad.mock.calls[0][0].name).toBe(testName);
+    expect(mockBeforeLoad.mock.calls[0][0].entry).toBe(reactSubAppEntry);
+  });
+
+  it("loadApp before registered and `entry` don't be provided will toorw Error", async () => {
+    GarfishInstance.run({
+      domGetter: '#container',
+      apps: [
+        {
+          name: 'react',
+          entry: reactSubAppEntry,
+        },
+      ],
+    });
+    const testName = 'react-unexisted';
+    expect(GarfishInstance.appInfos[testName]).toBeUndefined;
+
+    GarfishInstance.loadApp(testName).catch((e) =>
+      expect(e.message).toMatch(
+        'Please provide the entry parameters or registered in advance of the app.',
+      ),
+    );
+  });
 });

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -49,7 +49,7 @@ export const generateAppOptions = (
   garfish: interfaces.Garfish,
   options?: Omit<AppInfo, 'name'>,
 ): AppInfo => {
-  let appInfo = garfish.appInfos[appName] || {};
+  let appInfo = garfish.appInfos[appName] || { name: appName };
 
   // Merge register appInfo config and loadApp config
   if (isObject(options)) {


### PR DESCRIPTION
## Description

fix bug :  when loadApp before the app been registered successfully, or appName does not exists, the appInfo in `beforeLoad` hook call  will be  undefined.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested
yes. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
