### PR TITLE
fix: enhance esm parser

### DIFF
--- a/packages/core/__tests__/esmLoader.spec.ts
+++ b/packages/core/__tests__/esmLoader.spec.ts
@@ -1,44 +1,178 @@
+import { readFileSync } from 'fs';
+import { init, parse } from 'es-module-lexer';
 import {
-  STRING_REG,
-  COMMENT_REG,
-  DYNAMIC_IMPORT_REG,
+  ESModuleLoader,
+  getModuleImportProcessor,
 } from '../src/module/esModule';
 
 describe('Core: esm loader', () => {
-  it('comment reg', () => {
-    let code = `
-      a
-      // 1
-      //2
-      /* 1 */
-      /* //1 */
-      console.log(1/*f*/2)
-    `.trim();
-    code = code.replace(COMMENT_REG, '');
-    expect(code).toBe('a\n     \n     \n      \n      \n      console.log(12)');
+  it('replace static import module name', async () => {
+    await init;
+
+    const code = `
+      import React from 'react';
+      import { render } from 'react-dom';
+      // import lodash from 'lodash';
+      /* import VueRouter from 'vue-router'; */
+      console.log('render', render);
+      console.log(\`import Vue from 'vue';console.log(Vue);\`);
+      const importString = 'import router from "react-router"';
+    `;
+    const processImportModule = getModuleImportProcessor(code);
+    const [imports] = parse(code);
+    let result = ['', code];
+
+    for (let i = 0, length = imports.length; i < length; i++) {
+      result = processImportModule(imports[i], 'new-module-name');
+    }
+    expect(result.join('')).toBe(`
+      import React from 'new-module-name';
+      import { render } from 'new-module-name';
+      // import lodash from 'lodash';
+      /* import VueRouter from 'vue-router'; */
+      console.log('render', render);
+      console.log(\`import Vue from 'vue';console.log(Vue);\`);
+      const importString = 'import router from "react-router"';
+    `);
   });
 
-  it('string reg', () => {
-    let code =
-      'const a = \'chen\';const b = "tao";const c = \'ch\\\'en\';const tao = "t\\"tao"';
-    code = code.replace(STRING_REG, '');
-    expect(code).toBe('const a = ;const b = ;const c = ;const tao = ');
-    // eslint-disable-next-line quotes
-    code = "import a from './x.js';const d = \"import a from './x.js'\"";
-    code = code.replace(STRING_REG, '');
-    expect(code).toBe(';const d = ');
+  it('replace dynamic import keyword with "_import_"', async () => {
+    await init;
+
+    const code = `
+      import React from 'react';
+      import { render } from 'react-dom';
+      // import lodash from 'lodash';
+      /* import VueRouter from 'vue-router'; */
+      console.log('render', render);
+      console.log(\`import Vue from 'vue';console.log(Vue);\`);
+      const dynamicImport = import('react-router');
+    `;
+    const processImportModule = getModuleImportProcessor(code);
+    const [imports] = parse(code);
+    let result = ['', code];
+
+    for (let i = 0, length = imports.length; i < length; i++) {
+      result = processImportModule(imports[i]);
+    }
+    expect(result.join('')).toBe(`
+      import React from '';
+      import { render } from '';
+      // import lodash from 'lodash';
+      /* import VueRouter from 'vue-router'; */
+      console.log('render', render);
+      console.log(\`import Vue from 'vue';console.log(Vue);\`);
+      const dynamicImport = _import_('react-router');
+    `);
   });
 
-  it('dynamic import reg', () => {
-    let code =
-      // eslint-disable-next-line quotes
-      "import('a');const obj = { import(a) {\nimport('b')\n} };import(a + fn(import(a + b)) + 'a');";
-    code = code.replace(DYNAMIC_IMPORT_REG, (k1) =>
-      k1.replace('import', '_import_'),
-    );
-    expect(code).toBe(
-      // eslint-disable-next-line quotes
-      "_import_('a');const obj = { import(a) {\n_import_('b')\n} };_import_(a + fn(_import_(a + b)) + 'a');",
-    );
+  const baseUrl = 'http://www.test.com';
+  const esmFileMap = {
+    simpleEntry: `${baseUrl}/simpleEntry.js`,
+    esmA: `${baseUrl}/esmA.js`,
+    esmB: `${baseUrl}/esmB.js`,
+    esmC: `${baseUrl}/esmC.js`,
+    circularEntry: `${baseUrl}/circularEntry.js`,
+    circularEsmA: `${baseUrl}/circularEsmA.js`,
+    circularEsmB: `${baseUrl}/circularEsmB.js`,
+  };
+  const mockCache = {
+    [esmFileMap.esmA]: readFileSync(`${__dirname}/resources/js/esmA.js`, {
+      encoding: 'utf-8',
+    }),
+    [esmFileMap.esmB]: readFileSync(`${__dirname}/resources/js/esmB.js`, {
+      encoding: 'utf-8',
+    }),
+    [esmFileMap.esmC]: readFileSync(`${__dirname}/resources/js/esmC.js`, {
+      encoding: 'utf-8',
+    }),
+    [esmFileMap.circularEsmA]: readFileSync(
+      `${__dirname}/resources/js/circularEsmA.js`,
+      { encoding: 'utf-8' },
+    ),
+    [esmFileMap.circularEsmB]: readFileSync(
+      `${__dirname}/resources/js/circularEsmB.js`,
+      { encoding: 'utf-8' },
+    ),
+  };
+  const loader = new ESModuleLoader({
+    appId: 0,
+    name: 'unit test for esm module loader',
+    global: {},
+    context: {
+      loader: {
+        load({ url }) {
+          return {
+            resourceManager: {
+              url,
+              scriptCode: mockCache[url],
+            },
+          };
+        },
+      },
+    },
+    globalVarKey: 'globalVarKey',
+  } as any);
+  // @ts-ignore
+  loader.execModuleCode = () =>
+    // @ts-ignore
+    loader.app.global[loader.globalVarKey].resolve();
+  global.URL.revokeObjectURL = jest.fn();
+
+  it('load simple es module successfully', async () => {
+    let blobIndex = 0;
+    // @ts-ignore
+    loader.createBlobUrl = () => `blob:${++blobIndex}`;
+
+    const entryCode = 'import "./esmA.js";';
+    // @ts-ignore
+    await loader.load(entryCode, {}, esmFileMap.simpleEntry, {});
+
+    // @ts-ignore
+    const moduleCache = loader.moduleCache;
+    expect(moduleCache[esmFileMap.simpleEntry].blobUrl).toBe('blob:4');
+    expect(moduleCache[esmFileMap.simpleEntry].shellUrl).toBeUndefined();
+    expect(moduleCache[esmFileMap.esmA].blobUrl).toBe('blob:3');
+    expect(moduleCache[esmFileMap.esmA].shellUrl).toBeUndefined();
+    expect(moduleCache[esmFileMap.esmB].blobUrl).toBe('blob:1');
+    expect(moduleCache[esmFileMap.esmB].shellUrl).toBeUndefined();
+    expect(moduleCache[esmFileMap.esmC].blobUrl).toBe('blob:2');
+    expect(moduleCache[esmFileMap.esmC].shellUrl).toBeUndefined();
+
+    loader.destroy();
+    // @ts-ignore
+    expect(Object.keys(loader.moduleCache).length).toBe(0);
+  });
+
+  it('load circular dep es module successfully', async () => {
+    let blobIndex = 0;
+    const blobCodeList: string[] = [];
+    // @ts-ignore
+    loader.createBlobUrl = (code: string) => {
+      blobCodeList.push(code);
+      return `blob:${++blobIndex}`;
+    };
+    const entryCode = 'import "./circularEsmA.js";';
+    // @ts-ignore
+    await loader.load(entryCode, {}, esmFileMap.circularEntry, {});
+    // @ts-ignore
+    const moduleCache = loader.moduleCache;
+    expect(moduleCache[esmFileMap.circularEntry].blobUrl).toBe('blob:5');
+    expect(moduleCache[esmFileMap.circularEntry].shellUrl).toBeUndefined();
+    expect(moduleCache[esmFileMap.circularEsmA].blobUrl).toBe('blob:4');
+    expect(moduleCache[esmFileMap.circularEsmA].shellUrl).toBe('blob:2');
+    expect(moduleCache[esmFileMap.circularEsmB].blobUrl).toBe('blob:3');
+    expect(moduleCache[esmFileMap.circularEsmB].shellUrl).toBeUndefined();
+    expect(moduleCache[esmFileMap.esmC].blobUrl).toBe('blob:1');
+    expect(moduleCache[esmFileMap.esmC].shellUrl).toBeUndefined();
+
+    // shell code for module A
+    expect(blobCodeList[1])
+      .toBe(`export function u$$_(m){sayA=m.sayA,execSayB=m.execSayB}export let sayA;export let execSayB;export * from 'blob:1'
+//# sourceURL=http://www.test.com/circularEsmA.js?cycle`);
+
+    loader.destroy();
+    // @ts-ignore
+    expect(Object.keys(loader.moduleCache).length).toBe(0);
   });
 });

--- a/packages/core/__tests__/resources/js/circularEsmA.js
+++ b/packages/core/__tests__/resources/js/circularEsmA.js
@@ -1,0 +1,5 @@
+import { sayB } from './circularEsmB.js';
+export * from './esmC.js';
+
+export const sayA = () => console.log('say A');
+export const execSayB = () => sayB();

--- a/packages/core/__tests__/resources/js/circularEsmB.js
+++ b/packages/core/__tests__/resources/js/circularEsmB.js
@@ -1,0 +1,6 @@
+import { sayA } from './circularEsmA.js';
+
+export const sayB = () => {
+  sayA();
+  console.log('say B');
+};

--- a/packages/core/__tests__/resources/js/esmA.js
+++ b/packages/core/__tests__/resources/js/esmA.js
@@ -1,0 +1,4 @@
+import { esmContent } from './esmB.js';
+export * from './esmC.js';
+
+window.esmContent = esmContent;

--- a/packages/core/__tests__/resources/js/esmB.js
+++ b/packages/core/__tests__/resources/js/esmB.js
@@ -1,0 +1,1 @@
+export const esmContent = 'esm content';

--- a/packages/core/__tests__/resources/js/esmC.js
+++ b/packages/core/__tests__/resources/js/esmC.js
@@ -1,0 +1,1 @@
+export const esmC = 'esm content c';

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,6 +35,7 @@
     "@garfish/hooks": "workspace:*",
     "@garfish/loader": "workspace:*",
     "@garfish/utils": "workspace:*",
+    "es-module-lexer": "^0.10.5",
     "eventemitter2": "^6.4.5"
   },
   "devDependencies": {

--- a/packages/loader/src/appCache.ts
+++ b/packages/loader/src/appCache.ts
@@ -9,7 +9,7 @@ export enum FileTypes {
   template = 'template',
 }
 
-const MAX_SIZE = 1024 * 1024 * 15;
+const MAX_SIZE = 1024 * 1024 * 50;
 const DEFAULT_POLL = Symbol('__defaultBufferPoll__');
 const FILE_TYPES = [
   FileTypes.js,

--- a/packages/loader/src/index.ts
+++ b/packages/loader/src/index.ts
@@ -26,6 +26,9 @@ export type Manager =
   | JavaScriptManager;
 
 export interface LoaderOptions {
+  /**
+   * The unit is byte
+   */
   maxSize?: number;
 }
 
@@ -69,7 +72,7 @@ export class Loader {
     }>('beforeLoad'),
   });
 
-  private options: LoaderOptions; // The unit is "b"
+  private options: LoaderOptions;
   private loadingList: Record<string, null | Promise<CacheValue<any>>>;
   private cacheStore: { [name: string]: AppCacheContainer };
 
@@ -77,6 +80,10 @@ export class Loader {
     this.options = options || {};
     this.loadingList = Object.create(null);
     this.cacheStore = Object.create(null);
+  }
+
+  setOptions(options: Partial<LoaderOptions>) {
+    this.options = { ...this.options, ...options };
   }
 
   clear(scope: string, fileType?: FileTypes) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -703,11 +703,13 @@ importers:
       '@garfish/loader': workspace:*
       '@garfish/test-suite': workspace:*
       '@garfish/utils': workspace:*
+      es-module-lexer: ^0.10.5
       eventemitter2: ^6.4.5
     dependencies:
       '@garfish/hooks': link:../hooks
       '@garfish/loader': link:../loader
       '@garfish/utils': link:../utils
+      es-module-lexer: 0.10.5
       eventemitter2: 6.4.5
     devDependencies:
       '@garfish/test-suite': link:../test-suite
@@ -1241,6 +1243,7 @@ packages:
     engines: {node: ^12.20.0 || ^14.15.0 || >=16.10.0}
     dependencies:
       tslib: 2.4.0
+    dev: true
 
   /@angular/compiler/9.0.0_tslib@1.14.1:
     resolution: {integrity: sha512-ctjwuntPfZZT2mNj2NDIVu51t9cvbhl/16epc5xEwyzyDt76pX9UgwvY+MbXrf/C/FWwdtmNtfP698BKI+9leQ==}
@@ -13551,6 +13554,10 @@ packages:
       unbox-primitive: 1.0.1
     dev: true
 
+  /es-module-lexer/0.10.5:
+    resolution: {integrity: sha512-+7IwY/kiGAacQfY+YBhKMvEmyAJnw5grTUgjG85Pe7vcUI/6b7pZjZG8nQ7+48YhzEAEqrEgD2dCz/JIK+AYvw==}
+    dev: false
+
   /es-module-lexer/0.9.3:
     resolution: {integrity: sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==}
 
@@ -14122,6 +14129,7 @@ packages:
       esbuild-windows-64: 0.14.22
       esbuild-windows-arm64: 0.14.22
     dev: true
+    optional: true
 
   /esbuild/0.14.38:
     resolution: {integrity: sha512-12fzJ0fsm7gVZX1YQ1InkOE5f9Tl7cgf6JPYXRJtPIoE0zkWAbHdPHVPPaLi9tYAcEBqheGzqLn/3RdTOyBfcA==}
@@ -24189,6 +24197,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.1.1
       semver: 7.3.7
+    dev: false
 
   /sass-loader/12.4.0_sass@1.49.0+webpack@5.67.0:
     resolution: {integrity: sha512-7xN+8khDIzym1oL9XyS6zP6Ges+Bo2B2xbPrjdMHEYyV3AQYhd/wXeru++3ODHF0zMjYmVadblSKrPrjEkL8mg==}


### PR DESCRIPTION
利用社区的`es-module-lexer`方案重写了`ESModuleLoader`的import解析逻辑，现在的正则匹配方式没有很好地处理一些边界case，比如console.error(\`import Vue from 'vue';\`)，我们的项目里确实出现了一个库，里面有个console的提示就是类似这么写的。