### PR TITLE
Feat: Redefine AppInfo by PropsInfo

### DIFF
--- a/packages/bridge-react-v18/src/types.d.ts
+++ b/packages/bridge-react-v18/src/types.d.ts
@@ -6,6 +6,8 @@ export type PropsInfo = {
   props: Record<string, any>;
 };
 
+export type AppInfo = PropsInfo;
+
 export type LoadRootComponent<T> = (opts: PropsInfo) => Promise<T>;
 
 export type TypeComponent<T> =

--- a/packages/bridge-react/src/types.d.ts
+++ b/packages/bridge-react/src/types.d.ts
@@ -6,6 +6,8 @@ export type PropsInfo = {
   props: Record<string, any>;
 };
 
+export type AppInfo = PropsInfo;
+
 export type LoadRootComponent<T> = (opts: PropsInfo) => Promise<T>;
 export type TypeComponent<T> =
   | {

--- a/packages/bridge-vue-v2/src/types.d.ts
+++ b/packages/bridge-vue-v2/src/types.d.ts
@@ -6,6 +6,8 @@ export type PropsInfo = {
   props: Record<string, any>;
 };
 
+export type AppInfo = PropsInfo;
+
 export type LoadRootComponent<T> = (opts: PropsInfo) => Promise<T>;
 
 export type TypeComponent<T> =

--- a/packages/bridge-vue-v3/src/types.d.ts
+++ b/packages/bridge-vue-v3/src/types.d.ts
@@ -6,6 +6,8 @@ export type PropsInfo = {
   props: Record<string, any>;
 };
 
+export type AppInfo = PropsInfo;
+
 export type LoadRootComponent<T> = (opts: PropsInfo) => Promise<T>;
 
 export type TypeComponent<T> =


### PR DESCRIPTION
## Motivation and Context

There has type error where had import `@garfish/bridge-*`, such as where `dev/app-react-18/src/root.tsx:L6`

## What had I do

Bridge had define Props Info for an app info, but it will be meaningful which renamed be AppInfo than it, so I did to redefine to AppInfo


## How Has This Been Tested

Reinstall and reopen `dev/app-react-18/src/root.tsx:L6`

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
