### PR TITLE
fix: quick start link in cn readme

### DIFF
--- a/README.ch.md
+++ b/README.ch.md
@@ -37,7 +37,7 @@ yarn add garfish
 > 目前文档站点 ([Garfish](https://garfishjs.org/)) 仅提供了中文版本，不久后将提供英文版本文档
 
 - [关于 Garfish](https://garfishjs.org/guide)
-- [快速开始](https://garfishjs.org/quickStart)
+- [快速开始](https://www.garfishjs.org/guide/start)
 - [API](https://garfishjs.org/api)
 
 ## 功能


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->
* Found the url of quick start is wrong in readme of Chinese version.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[#533](https://github.com/modern-js-dev/garfish/issues/533)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
* Fix url

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Add tests to ensure that user can be redirected to correct address

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
