### PR TITLE
fix(router): appInfo.basename is undefined cause rootPath caculate error

### DIFF
--- a/packages/router/src/utils/urlUt.ts
+++ b/packages/router/src/utils/urlUt.ts
@@ -56,7 +56,7 @@ export function getPath(basename: string = '/', pathname?: string) {
 
 export function getAppRootPath(appInfo: interfaces.AppInfo) {
   const path = getPath(appInfo.basename, location.pathname);
-  let appRootPath = appInfo.basename === '/' ? '' : appInfo.basename;
+  let appRootPath = appInfo.basename === '/' ? '' : (appInfo.basename || '');
   if (typeof appInfo.activeWhen === 'string') {
     appRootPath += appInfo.activeWhen;
   } else {


### PR DESCRIPTION
## Description

when registerApp, if the appInfo.basename is undefined will cause rootPath caculate error, then the microApp can not mount 
correctly
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
