### PR TITLE
fix(sandbox): use micro task replace macro task and delete restore document.currentScript behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "workspace-tools": "0.16.2",
     "zx": "4.2.0"
   },
-  "version": "1.11.2",
+  "version": "1.11.3",
   "packageManager": "pnpm@7.6.0",
   "engines": {
     "node": ">=16.14.0"

--- a/packages/bridge-react-v18/package.json
+++ b/packages/bridge-react-v18/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/bridge-react-v18",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "description": "garfish module.",
   "keywords": [
     "garfish",

--- a/packages/bridge-react/package.json
+++ b/packages/bridge-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/bridge-react",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "description": "garfish module.",
   "keywords": [
     "garfish",

--- a/packages/bridge-vue-v2/package.json
+++ b/packages/bridge-vue-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/bridge-vue-v2",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "description": "garfish vue bridge for v2.",
   "keywords": [
     "garfish",

--- a/packages/bridge-vue-v3/package.json
+++ b/packages/bridge-vue-v3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/bridge-vue-v3",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "description": "garfish vue bridge for v3.",
   "keywords": [
     "garfish",

--- a/packages/browser-snapshot/package.json
+++ b/packages/browser-snapshot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/browser-snapshot",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "description": "browser-snapshot module.",
   "keywords": [
     "garfish",

--- a/packages/browser-vm/package.json
+++ b/packages/browser-vm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/browser-vm",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "description": "vm-sandbox module.",
   "keywords": [
     "garfish",

--- a/packages/browser-vm/src/sandbox.ts
+++ b/packages/browser-vm/src/sandbox.ts
@@ -351,7 +351,7 @@ export class Sandbox {
     } catch (e) {
       this.processExecError(e, url, env, options);
     } finally {
-      setTimeout(revertCurrentScript,0);
+      Promise.resolve().then(revertCurrentScript);
     }
 
     this.hooks.lifecycle.afterInvoke.emit(codeRef, url, env, options);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/core",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "description": "core module.",
   "keywords": [
     "garfish",

--- a/packages/core/src/module/app.ts
+++ b/packages/core/src/module/app.ts
@@ -233,7 +233,7 @@ export class App {
         };
       }
       evalWithEnv(`;${code}`, env, this.global);
-      setTimeout(revertCurrentScript,0);
+      Promise.resolve().then(revertCurrentScript);
     }
   }
 

--- a/packages/css-scope/package.json
+++ b/packages/css-scope/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/css-scope",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "description": "css scope",
   "keywords": [
     "garfish",

--- a/packages/es-module/package.json
+++ b/packages/es-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/es-module",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "description": "es module polyfill",
   "keywords": [
     "garfish",

--- a/packages/garfish/package.json
+++ b/packages/garfish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garfish",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "description": "garfish module.",
   "keywords": [
     "garfish",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/hooks",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "description": "hooks module.",
   "keywords": [
     "garfish",

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/loader",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "description": "loader module.",
   "keywords": [
     "garfish",

--- a/packages/remote-module/package.json
+++ b/packages/remote-module/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/remote-module",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "description": "remote-module module.",
   "keywords": [
     "garfish",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/router",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "description": "router module.",
   "keywords": [
     "garfish",

--- a/packages/test-suite/package.json
+++ b/packages/test-suite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/test-suite",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "description": "garfish test suite.",
   "keywords": [
     "garfish",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garfish/utils",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "description": "utils module.",
   "keywords": [
     "garfish",

--- a/packages/utils/src/utils.ts
+++ b/packages/utils/src/utils.ts
@@ -414,7 +414,7 @@ export function setDocCurrentScript(
   if (async) {
     el.setAttribute('async', 'true');
   }
-
+ 
   const set = (val) => {
     try {
       if (define) {
@@ -434,7 +434,7 @@ export function setDocCurrentScript(
   };
 
   set(el);
-  return () => set(null);
+  return () => safeWrapper(()=> delete target.currentScript);
 }
 
 export function _extends(d, b) {


### PR DESCRIPTION
fix(sandbox): use micro task replace macro task and delete restore document.currentScript behavior

## Description

* document.currentScript default behavior is to clear after microtask
  * https://html.spec.whatwg.org/#execute-the-script-block
  * https://bugzilla.mozilla.org/show_bug.cgi?id=1620505
* use delete to restore document.currentScript default  behavior

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
