### PR TITLE
fix(core): fix loadApp lost appInfo information after the second merge

### DIFF
--- a/packages/core/__tests__/loadApp.spec.ts
+++ b/packages/core/__tests__/loadApp.spec.ts
@@ -161,11 +161,8 @@ describe('Core: load process', () => {
   });
 
   it('config provided by options in loadApp will have the highest priority after config merged', async () => {
-    const mockBeforeLoad = jest.fn(() => {
-      GarfishInstance.appInfos['vue-app'] = {
-        name: 'vue-app',
-        entry: vue3SubAppEntry,
-      };
+    const mockBeforeLoad = jest.fn((appInfo) => {
+      appInfo.entry = vue3SubAppEntry;
     });
 
     GarfishInstance.run({
@@ -182,10 +179,16 @@ describe('Core: load process', () => {
     await expect(
       GarfishInstance.loadApp('vue-app', {
         domGetter: '#container',
+        props: {
+          aaa: '123'
+        }
       }),
     ).resolves.toMatchObject({
       appInfo: {
         entry: vue3SubAppEntry,
+        props: {
+          aaa: '123'
+        }
       },
     });
 

--- a/packages/core/src/garfish.ts
+++ b/packages/core/src/garfish.ts
@@ -173,7 +173,7 @@ export class Garfish extends EventEmitter2 {
       }
 
       //merge configs again after beforeLoad for the reason of app may be re-registered during beforeLoad resulting in an incorrect information
-      appInfo = generateAppOptions(appName, this, options);
+      appInfo = generateAppOptions(appName, this, appInfo);
 
       assert(
         appInfo.entry,


### PR DESCRIPTION
## Description
fix: lost appInfo information after the second merge in loadApp

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
