### PR TITLE
fix(browser-vm): fakeFetch method input type judgment

### DIFF
--- a/packages/browser-vm/src/modules/network.ts
+++ b/packages/browser-vm/src/modules/network.ts
@@ -37,7 +37,7 @@ export function networkModule(sandbox: Sandbox) {
 
       const url = arguments[1];
 
-      if(sandbox.options.addSourceList){
+      if (sandbox.options.addSourceList) {
         sandbox.options.addSourceList({
           tagName: 'xmlhttprequest',
           url,
@@ -73,8 +73,11 @@ export function networkModule(sandbox: Sandbox) {
     if (needFix(input) && baseUrl) {
       input = transformUrl(baseUrl, input);
     }
-    if(sandbox.options.addSourceList){
-      sandbox.options.addSourceList({ tagName: 'fetch', url: input });
+    if (sandbox.options.addSourceList) {
+      sandbox.options.addSourceList({
+        tagName: 'fetch',
+        url: input instanceof Request ? input.url : input,
+      });
     }
     let controller;
     if (!hasOwn(options, 'signal') && window.AbortController) {


### PR DESCRIPTION
## Description
fakeFetch函数中并没有对 input 的类型做判断 导致fetch请求失败。addSourceList方法中url参数需要是string类型
<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
