### PR TITLE
fix: issue SVG camel tag is not support #585, SVG setAttribute xmlns:xlink failed #584

### DIFF
--- a/packages/utils/__tests__/domApis.spec.ts
+++ b/packages/utils/__tests__/domApis.spec.ts
@@ -1,0 +1,37 @@
+import { DOMApis } from '../src/domApis';
+
+describe('Garfish shared domApis', () => {
+  const domApis = new DOMApis(document);
+  it('set Attribute SVG xmlns:xlink', () => {
+    const svg = domApis.createElement({
+      type: 'element',
+      key: 'svg',
+      tagName: 'svg',
+      children: [],
+      attributes: [
+        {
+          key: 'xmlns:xlink',
+          value: 'http://www.w3.org/1999/xlink',
+        },
+      ],
+    });
+    expect(svg.outerHTML).toBe('<svg xmlns:xlink="http://www.w3.org/1999/xlink"></svg>');
+  });
+
+  it('set Attribute SVG xlink:href', () => {
+    const use = domApis.createElement({
+      type: 'element',
+      key: 'use',
+      tagName: 'use',
+      children: [],
+      attributes: [
+        {
+          key: 'xlink:href',
+          value: '#image1_1060_8858',
+        },
+      ],
+    });
+    expect(use.outerHTML).toBe('<use xlink:href="#image1_1060_8858"></use>');
+  });
+
+})

--- a/packages/utils/__tests__/templateParse.spec.ts
+++ b/packages/utils/__tests__/templateParse.spec.ts
@@ -1,0 +1,65 @@
+import { templateParse } from '../src/templateParse';
+
+
+function Attributes(this: any, { name, value }) {
+  this.key = name;
+  this.value = value;
+}
+
+describe('Garfish shared templateParse', () => {
+  it('parse SVG feFlood', () => {
+    const [ast] = templateParse('<head></head><body><svg xmlns="http://www.w3.org/2000/svg"><feFlood flood-opacity="0"/></svg></body>', []);
+    expect(ast).toEqual([{
+      type: 'element',
+      tagName: 'head',
+      attributes: [],
+      children: [],
+    },{
+      type: 'element',
+      tagName: 'body',
+      attributes: [],
+      children: [{
+        type: 'element',
+        tagName: 'svg',
+        attributes: [new Attributes({
+          name: 'xmlns',
+          value: 'http://www.w3.org/2000/svg',
+        })],
+        children: [
+          {
+            type: 'element',
+            tagName: 'feFlood',
+            attributes: [new Attributes({
+              name: 'flood-opacity',
+              value: '0',
+            })],
+            children: [],
+          },
+        ],
+      }],
+    }])
+  });
+
+  it('parse Uppercase DIV', () => {
+    const [ast] = templateParse('<head></head><body><DIV id="div"/></body>', []);
+    expect(ast).toEqual([{
+      type: 'element',
+      tagName: 'head',
+      attributes: [],
+      children: [],
+    },{
+      type: 'element',
+      tagName: 'body',
+      attributes: [],
+      children: [{
+        type: 'element',
+        tagName: 'div',
+        attributes: [new Attributes({
+          name: 'id',
+          value: 'div',
+        })],
+        children: [],
+      }],
+    }]);
+  });
+});

--- a/packages/utils/src/domApis.ts
+++ b/packages/utils/src/domApis.ts
@@ -21,6 +21,8 @@ const ns = 'http://www.w3.org/2000/svg';
 const xlinkNS = 'http://www.w3.org/1999/xlink'; // xmlns:xlink
 const xmlNS = 'http://www.w3.org/XML/1998/namespace'; // xmlns
 
+const xlinkPrefix = 'xlink';
+
 // https://developer.mozilla.org/en-US/docs/Web/SVG/Element
 const SVG_TAGS =
   'svg,animate,animateMotion,animateTransform,circle,clipPath,color-profile,' +
@@ -35,6 +37,10 @@ const SVG_TAGS =
   'text,textPath,title,tspan,unknown,use,view';
 
 const isSVG = makeMap(SVG_TAGS.split(','));
+
+export function changeTagNameToLowerCase(tagName: string) {
+ return isSVG(tagName) ? tagName : tagName.toLowerCase();
+}
 
 function attributesString(attributes: Node['attributes']) {
   if (!attributes || attributes.length === 0) return '';
@@ -184,7 +190,7 @@ export class DOMApis {
             el.setAttribute(key, value);
           } else if (key.charCodeAt(3) === colonChar) {
             el.setAttributeNS(xmlNS, key, value);
-          } else if (key.charCodeAt(5) === colonChar) {
+          } else if (key.charCodeAt(5) === colonChar && key.slice(0, 5) === xlinkPrefix) {
             el.setAttributeNS(xlinkNS, key, value);
           } else {
             el.setAttribute(key, value);

--- a/packages/utils/src/templateParse.ts
+++ b/packages/utils/src/templateParse.ts
@@ -1,5 +1,5 @@
 import { error } from './utils';
-import { Node as VNode } from './domApis';
+import { changeTagNameToLowerCase, Node as VNode } from './domApis';
 
 enum ElementType {
   TEXT = 3,
@@ -48,7 +48,7 @@ const createElement = (el: Element, filter: (el: VNode) => VNode) => {
     case ElementType.ELEMENT:
       return filter({
         type: 'element',
-        tagName: el.tagName.toLowerCase(),
+        tagName: changeTagNameToLowerCase(el.tagName),
         attributes: generateAttributes(el),
         children: Array.from(el.childNodes).map((node) => {
           return createElement(node as Element, filter);


### PR DESCRIPTION
## Description

<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->
fix bugs:
* SVG camel tag is not support: add SVG judge for template parse
* SVG setAttribute xmlns:xlink failed: make sure the prefix is `xlink`, only `xlink:XXX` attribute need xlink namespace.

## Related Issue
* SVG camel tag is not support https://github.com/modern-js-dev/garfish/issues/585
* SVG setAttribute xmlns:xlink failed https://github.com/modern-js-dev/garfish/issues/584

## Motivation and Context
garfish render SVG in template error.

## How Has This Been Tested

* SVG camel tag is not support: test SVG `feFlood` tag and `DIV`, make sure toLowercase is enable for normal tag.
* SVG setAttribute xmlns:xlink: test `xmlns:xlink` and `xlink:href`, make sure only `xlink:href` is set with xlink namespace.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
