### PR TITLE
fix: add baseUrl for sourceList to avoid lose collection

### DIFF
--- a/packages/core/src/module/app.ts
+++ b/packages/core/src/module/app.ts
@@ -171,21 +171,31 @@ export class App {
     if (this.appInfo.disableSourceListCollect) return;
     if (Array.isArray(sourceInfo)){
       let nSourceList = sourceInfo.filter(item => {
-        if (!this.sourceListMap.has(item.url) && item.url.startsWith('http')) {
-          this.sourceListMap.set(item.url, item);
+        const dup = Object.assign({}, item);
+        dup.url = dup.url.startsWith('/') ?
+          `${location.origin}${dup.url}` :
+          dup.url;
+
+        if (!this.sourceListMap.has(dup.url) && dup.url.startsWith('http')) {
+          this.sourceListMap.set(dup.url, dup);
           return true;
         }
         return false;
       });
       this.sourceList = this.sourceList.concat(nSourceList);
     } else {
-      if (!this.sourceListMap.get(sourceInfo.url) && sourceInfo.url.startsWith('http')){
-        this.sourceList.push(sourceInfo);
-        this.sourceListMap.set(sourceInfo.url, sourceInfo);
+      const dup = Object.assign({}, sourceInfo);
+      dup.url = dup.url.startsWith('/') ?
+        `${location.origin}${dup.url}` :
+        dup.url;
+
+      if (!this.sourceListMap.get(dup.url) && dup.url.startsWith('http')){
+        this.sourceList.push(dup);
+        this.sourceListMap.set(dup.url, dup);
       }
     }
   }
-  
+
   getProvider() {
     return this.provider
       ? Promise.resolve(this.provider)


### PR DESCRIPTION
## Description

BaseUrl should be provided, or the collect condition will filter the source url, which will cause monitor sdk lose report

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
