### PR TITLE
fix(loader): fix the loader return the same entryManager when multi apps mount at the same time

### DIFF
--- a/packages/core/__tests__/loadApp.spec.ts
+++ b/packages/core/__tests__/loadApp.spec.ts
@@ -10,7 +10,7 @@ import assert from 'assert';
 
 describe('Core: load process', () => {
   let GarfishInstance: Garfish;
-  let container;
+  let container, app1, app2, app3;
 
   const vueSubAppEntry = './resources/vueApp.html';
   const reactSubAppEntry = './resources/reactApp.html';
@@ -26,6 +26,19 @@ describe('Core: load process', () => {
     container = document.createElement('div');
     container.setAttribute('id', 'container');
     document.body.appendChild(container);
+
+    app1 = document.createElement('div');
+    app1.setAttribute('id', 'app1');
+    container.appendChild(app1);
+
+    app2 = document.createElement('div');
+    app2.setAttribute('id', 'app2');
+    container.appendChild(app2);
+
+    app3 = document.createElement('div');
+    app3.setAttribute('id', 'app3');
+    container.appendChild(app3);
+
     GarfishInstance = new Garfish({});
   });
 
@@ -379,6 +392,75 @@ describe('Core: load process', () => {
     expect(mockBeforeLoad.mock.calls[0][0]).not.toBeUndefined;
     expect(mockBeforeLoad.mock.calls[0][0].name).toBe(testName);
     expect(mockBeforeLoad.mock.calls[0][0].entry).toBe(reactSubAppEntry);
+  });
+
+
+  it('multiple applications with the same entry are serially mounted, entryManager is not the same instance', async () => {
+    const createApp = jest.fn(async (appName, dom, entry) => {
+      GarfishInstance.registerApp({
+        name: appName,
+        entry,
+      });
+
+      const app = await GarfishInstance.loadApp(appName, { domGetter: dom });
+      app && await app.mount();
+      return app;
+    });
+
+    const app1 = await createApp('app1', '#app1', vueSubAppEntry);
+    const app2 = await createApp('app2', '#app2', vueSubAppEntry);
+    const app3 = await createApp('app3', '#app2', vueSubAppEntry);
+
+    assert(app1, 'app should be loaded');
+    assert(app2, 'app should be loaded');
+    assert(app3, 'app should be loaded');
+
+
+    expect(app1).toHaveProperty('entryManager');
+    expect(app2).toHaveProperty('entryManager');
+    expect(app3).toHaveProperty('entryManager');
+
+    expect(app1.entryManager).not.toBe(app2.entryManager);
+    expect(app2.entryManager).not.toBe(app3.entryManager);
+    expect(app1.entryManager).not.toBe(app3.entryManager);
+  });
+
+  it('multiple applications of the same entry are mounted at the same time, entryManager is not the same instance', async () => {
+    const createApp = jest.fn(async (appName, dom, entry) => {
+      GarfishInstance.registerApp({
+        name: appName,
+        entry,
+      });
+
+      const app = await GarfishInstance.loadApp(appName, { domGetter: dom });
+      app && await app.mount();
+      return app;
+    });
+
+    const app1 = createApp('app1', '#app1', vueSubAppEntry);
+    const app2 = createApp('app2', '#app2', vueSubAppEntry);
+    const app3 = createApp('app3', '#app2', vueSubAppEntry);
+
+    assert(app1, 'app should be loaded');
+    assert(app2, 'app should be loaded');
+    assert(app3, 'app should be loaded');
+
+    await expect(app1).resolves.toHaveProperty('entryManager');
+    await expect(app2).resolves.toHaveProperty('entryManager');
+    await expect(app3).resolves.toHaveProperty('entryManager');
+
+    expect(GarfishInstance.activeApps[0]).not.toBe(null);
+    expect(GarfishInstance.activeApps[0]).toHaveProperty('entryManager');
+
+    expect(GarfishInstance.activeApps[1]).not.toBe(null);
+    expect(GarfishInstance.activeApps[1]).toHaveProperty('entryManager');
+
+    expect(GarfishInstance.activeApps[2]).not.toBe(null);
+    expect(GarfishInstance.activeApps[2]).toHaveProperty('entryManager');
+
+    expect(GarfishInstance.activeApps[0].entryManager).not.toBe(GarfishInstance.activeApps[1].entryManager)
+    expect(GarfishInstance.activeApps[1].entryManager).not.toBe(GarfishInstance.activeApps[2].entryManager)
+    expect(GarfishInstance.activeApps[0].entryManager).not.toBe(GarfishInstance.activeApps[2].entryManager)
   });
 
   it('loadApp before registered and `entry` don\'t be provided will throw Error', async () => {

--- a/packages/core/__tests__/loadApp.spec.ts
+++ b/packages/core/__tests__/loadApp.spec.ts
@@ -113,7 +113,7 @@ describe('Core: load process', () => {
     document.body.removeChild(container);
   });
 
-  it("throw error when provide an 'name' opts in options", async () => {
+  it('throw error when provide an \'name\' opts in options', async () => {
     await expect(GarfishInstance.loadApp('vue-app')).rejects.toThrow();
   });
 
@@ -250,7 +250,7 @@ describe('Core: load process', () => {
     );
   });
 
-  it('load the same app while return the cache instance if cache is true', async () => {
+  it('load the same app will return the cache appInstance if the config cache is true', async () => {
     await GarfishInstance.run({
       domGetter: '#container',
       apps: [
@@ -270,31 +270,10 @@ describe('Core: load process', () => {
 
     expect(app1.mounted).toBe(true);
     expect(app2.mounted).toEqual(app1.mounted);
+    expect(app1).toBe(app2);
   });
 
-  it('load the same app while return the cache instance if cache is set true', async () => {
-    await GarfishInstance.run({
-      domGetter: '#container',
-      apps: [
-        {
-          name: 'vue-app',
-          entry: vueSubAppEntry,
-          cache: false,
-        },
-      ],
-    });
-
-    const app1 = await GarfishInstance.loadApp('vue-app');
-    assert(app1, 'app2 should be loaded');
-    await app1.mount();
-    const app2 = await GarfishInstance.loadApp('vue-app');
-    assert(app2, 'app2 should be loaded');
-
-    expect(app1.mounted).toBe(true);
-    expect(app2.mounted).not.toEqual(app1.mounted);
-  });
-
-  it('load the same app while return the cache instance if cache is set false', async () => {
+  it('load the same app will not return the cached appInstance if the config cache is false', async () => {
     GarfishInstance.run({
       domGetter: '#container',
       apps: [
@@ -318,7 +297,36 @@ describe('Core: load process', () => {
 
     expect(app1.mounted).toBe(true);
     expect(app2.mounted).toBe(false);
+    expect(app2.mounted).not.toEqual(app1.mounted);
     expect(app2.appInfo.entry).toEqual(vue3SubAppEntry);
+  });
+
+  it('load the same app will return the cached appInstance if the config cache is true and the app configs will not updates', async () => {
+    GarfishInstance.run({
+      domGetter: '#container',
+      apps: [
+        {
+          name: 'vue-app',
+          entry: vueSubAppEntry,
+          cache: true,
+        },
+      ],
+    });
+
+    const app1 = await GarfishInstance.loadApp('vue-app');
+    assert(app1, 'app2 should be loaded');
+    await app1.mount();
+
+    const app2 = await GarfishInstance.loadApp('vue-app', {
+      entry: vue3SubAppEntry,
+      cache: true,
+    });
+    assert(app2, 'app2 should be loaded');
+
+    expect(app1.mounted).toBe(true);
+    expect(app2.mounted).toEqual(app1.mounted);
+    expect(app1).toBe(app2);
+    expect(app1.appInfo.entry).toEqual(vueSubAppEntry);
   });
 
   it('destroy the app during rendering and then render again', async () => {
@@ -373,7 +381,7 @@ describe('Core: load process', () => {
     expect(mockBeforeLoad.mock.calls[0][0].entry).toBe(reactSubAppEntry);
   });
 
-  it("loadApp before registered and `entry` don't be provided will toorw Error", async () => {
+  it('loadApp before registered and `entry` don\'t be provided will throw Error', async () => {
     GarfishInstance.run({
       domGetter: '#container',
       apps: [

--- a/packages/loader/src/index.ts
+++ b/packages/loader/src/index.ts
@@ -95,7 +95,7 @@ export class Loader {
   });
 
   private options: LoaderOptions;
-  private loadingList: Record<string, null | Promise<CacheValue<any>>>;
+  private loadingList: Record<string, Record<string, Promise<CacheValue<any>>>>;
   private cacheStore: { [name: string]: AppCacheContainer };
 
   constructor(options?: LoaderOptions) {
@@ -158,8 +158,15 @@ export class Loader {
     const { options, loadingList, cacheStore } = this;
 
     const res = loadingList[url];
-    if (res) {
-      return res;
+    // 增加 scope 作为缓存区分，相同 scope 的 loader 才做缓存
+    // 否则可能出现，url 相同，不同子应用实例的共享同一 entryManager，在多个子应用同时 mount 时，在 vm sandbox 中会对 entryManager 的 document 进行赋值(app.entryManager.DOMApis.document = sandbox.global.document)
+    // 这样当最后一个子应用实例对 entryManager.DOMApis.document 赋值时，其余子应用的 entryManager.DOMApis.document 将会指向最后一次实例化的子应用的 sandbox.global.document 变量，
+    // dom 元素被创建时挂载的 sandbox id 为最后一个子应用的 sandbox id
+    // 子应用通过 createElement 方法创建的 dom 元素将会被当做最后一个子应用的 deferClearEffects 副作用收集。
+    // 当最后一个子应用被卸载时，其它子应用也将一起被卸载
+
+    if (res && Object.keys(res).includes(scope)) {
+      return res[scope]
     }
 
     let appCacheContainer = cacheStore[scope];
@@ -257,10 +264,11 @@ export class Loader {
         throw e; // Let the upper application catch the error
       })
       .finally(() => {
-        loadingList[url] = null;
+        // 有 scope 区分之后无需置空
+        // loadingList[url][scope] = null
       });
 
-    loadingList[url] = loadRes;
+    loadingList[url] ? loadingList[url][scope] = loadRes : loadingList[url] = { [scope]: loadRes };
     return loadRes;
   }
 }


### PR DESCRIPTION
fix(loader): fix the loader return the same loader when multi apps mount at the same time

## Description

When multiple applications with the same entry are mounted at the same time, garfish will collect the dom created by the previous application as a side effect into the side effect category of the last sub-application. When the last sub application is unmount, it will cause all applications to be uninstalled.

This is because the loader of garfish will cache the loader instance for the same entry url, and return the previous loader instance when the entry is the same. In this way, when multiple sub applications are mounted at the same time, if these applications have the same entry, they will point to the same loader instance. In the vm sandbox, the document object of the loader will be rewritten to the document object of the sandbox. All loaders will also point to the sandbox document object of the last mounted application. Then the dom created by these applications will be collected as a side effect of the last application, causing some errors to occur.


<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
