### PR TITLE
fix(core): fix customRenderer execute script failed

### DIFF
--- a/packages/core/__tests__/appInstance.spec.ts
+++ b/packages/core/__tests__/appInstance.spec.ts
@@ -13,6 +13,7 @@ describe('Core: appInstance', () => {
   let container;
 
   const vueSubAppEntry = './resources/vueApp.html';
+  const viteAppEntry = './resources/viteApp.html';
   const reactSubAppEntry = './resources/reactApp.html';
   const vue3AppRenderNode = 'hello-world-vue3';
   const vue3SubAppEntry = './resources/vue3App.html';
@@ -52,4 +53,25 @@ describe('Core: appInstance', () => {
     await app.unmount();
     expect(GarfishInstance.activeApps[0]).toBeUndefined();
   });
+
+  it('mount apps with inline script code using script dom', async () => {
+    const app = await GarfishInstance.loadApp('vite-app', {
+      entry: viteAppEntry,
+      domGetter: '#container',
+    });
+
+    assert(app, 'app should be defined');
+    await app.mount();
+    expect(GarfishInstance.activeApps[0]).toBe(app);
+
+    app.hide();
+    expect(GarfishInstance.activeApps[0]).toBeUndefined();
+
+    await app.show();
+    expect(GarfishInstance.activeApps[0]).toBe(app);
+
+    await app.unmount();
+    expect(GarfishInstance.activeApps[0]).toBeUndefined();
+  });
+
 });

--- a/packages/core/__tests__/resources/viteApp.html
+++ b/packages/core/__tests__/resources/viteApp.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>vite sub app</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script id="vite-legacy-entry" data-src="//test-vite-legacy-entry-resource.js">
+      const dataSrcUrl = document.getElementById('vite-legacy-entry').getAttribute('data-src')
+      console.log(dataSrcUrl);
+    </script>
+
+    <script>
+      if (typeof __GARFISH_EXPORTS__ !== 'undefined') {
+        __GARFISH_EXPORTS__.provider = () => {
+          return {
+            render ({ dom , basename }) {
+              let newContent = document.createElement('div');
+              newContent.setAttribute('id', 'hello-world');
+              dom.querySelector('#app').appendChild(newContent);
+            },
+            destroy ({ dom , basename }){
+              dom.querySelector('#app').removeChild(dom.querySelector('#hello-world'));
+            }
+          }
+        }
+      }
+    </script>
+  </body>
+</html>

--- a/packages/core/src/module/app.ts
+++ b/packages/core/src/module/app.ts
@@ -611,6 +611,16 @@ export class App {
             }
           });
 
+          // if the script node has an id attribute, create a script node before executing the script
+          const hasIdKey = node.attributes.find((attribute) => attribute.key === 'id');
+          if (hasIdKey) {
+            const _node = entryManager.cloneNode(node)
+            _node.tagName = 'div';
+            _node.type = 'element'
+            const _domEl = DOMApis.createElement(_node);
+            htmlNode.appendChild(_domEl);
+          }
+
           const targetUrl = url || this.appInfo.entry;
           this.execScript(scriptCode, {}, targetUrl, {
             isModule,


### PR DESCRIPTION
## Description

- In customRenderer, script is added to dom as comment node. Inline script execution content is extracted and executed separately as scriptCode. When executing scriptCode, if the script needs to get the script dom node, it will not be able to get it and the script execution will fail, which is not as expected.

- add judgment in customRenderer's processing of script: if the current script node attribute contains id attribute (it is generally considered that this node may be used for acquisition), then this node will also be inserted into the document flow as a dom node, and then Execute the scriptCode to get the content of the node. this will fix this problem.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
