### PR TITLE
fix(browser-vm): improve transferProps function to correctly copy function properties

### DIFF
--- a/packages/browser-vm/__tests__/sandbox.spec.ts
+++ b/packages/browser-vm/__tests__/sandbox.spec.ts
@@ -242,4 +242,36 @@ describe('Sandbox', () => {
       { next }
     );
   });
+
+  it('transferProps robustness test', (next) => {
+    // 测试不可配置属性
+    const testFunc = () => {};
+    Object.defineProperty(testFunc, 'readonly', {
+      value: 'cannot-change',
+      writable: false,
+      configurable: false
+    });
+    
+    // 测试可配置属性
+    Object.defineProperty(testFunc, 'configurable', {
+      value: 'can-change',
+      writable: true,
+      configurable: true
+    });
+    
+    // 测试普通属性
+    testFunc.normal = 'normal-value';
+    
+    (window as any).testFunc = testFunc;
+    
+    sandbox.execScript(
+      go(`
+        expect(window.testFunc.readonly).toBe('cannot-change');
+        expect(window.testFunc.configurable).toBe('can-change');
+        expect(window.testFunc.normal).toBe('normal-value');
+        next();
+      `),
+      { next }
+    );
+  });
 });


### PR DESCRIPTION
## Description
fix(browser-vm): improve transferProps function to correctly copy function properties


<!--- Provide a general summary of your changes in the Title above -->
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation.
