### PR TITLE
fix(browser-vm): clean up completed timeout records

### DIFF
--- a/packages/browser-vm/__tests__/modules/timer.spec.ts
+++ b/packages/browser-vm/__tests__/modules/timer.spec.ts
@@ -1,0 +1,94 @@
+import type { Sandbox } from '../../src/sandbox';
+
+describe('timer module', () => {
+  const createSandbox = (disableCollect = false) =>
+    ({ options: { disableCollect } } as Sandbox);
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it('removes a timeout after it runs', () => {
+    const clearTimeout = jest.spyOn(window, 'clearTimeout');
+    const { timeoutModule } = require('../../src/modules/timer');
+    const timer = timeoutModule(createSandbox());
+    const callback = jest.fn();
+
+    timer.override.setTimeout(callback, 10, 'value');
+    jest.advanceTimersByTime(10);
+
+    expect(callback).toHaveBeenCalledWith('value');
+    expect(callback.mock.instances[0]).toBe(window);
+    clearTimeout.mockClear();
+    timer.recover();
+    expect(clearTimeout).not.toHaveBeenCalled();
+  });
+
+  it('supports string handlers without retaining completed timeouts', () => {
+    const clearTimeout = jest.spyOn(window, 'clearTimeout');
+    const { timeoutModule } = require('../../src/modules/timer');
+    const timer = timeoutModule(createSandbox());
+    const originalName = window.name;
+    window.name = 'before timeout';
+
+    timer.override.setTimeout('window.name = String(1)', 10);
+    jest.advanceTimersByTime(10);
+
+    expect(window.name).toBe('1');
+    clearTimeout.mockClear();
+    timer.recover();
+    expect(clearTimeout).not.toHaveBeenCalled();
+    window.name = originalName;
+  });
+
+  it('removes a timeout when it is cleared explicitly', () => {
+    const clearTimeout = jest.spyOn(window, 'clearTimeout');
+    const { timeoutModule } = require('../../src/modules/timer');
+    const timer = timeoutModule(createSandbox());
+    const timeoutId = timer.override.setTimeout(() => {}, 10);
+
+    timer.override.clearTimeout(timeoutId);
+    expect(clearTimeout).toHaveBeenCalledWith(timeoutId);
+
+    clearTimeout.mockClear();
+    timer.recover();
+    expect(clearTimeout).not.toHaveBeenCalled();
+  });
+
+  it('clears timeout records after recovery', () => {
+    const clearTimeout = jest.spyOn(window, 'clearTimeout');
+    const { timeoutModule } = require('../../src/modules/timer');
+    const timer = timeoutModule(createSandbox());
+    const firstId = timer.override.setTimeout(() => {}, 10);
+    const secondId = timer.override.setTimeout(() => {}, 20);
+
+    timer.recover();
+    expect(clearTimeout).toHaveBeenCalledTimes(2);
+    expect(clearTimeout).toHaveBeenCalledWith(firstId);
+    expect(clearTimeout).toHaveBeenCalledWith(secondId);
+
+    clearTimeout.mockClear();
+    timer.recover();
+    expect(clearTimeout).not.toHaveBeenCalled();
+  });
+
+  it('clears interval records after recovery', () => {
+    const clearInterval = jest.spyOn(window, 'clearInterval');
+    const { intervalModule } = require('../../src/modules/timer');
+    const timer = intervalModule(createSandbox());
+    const intervalId = timer.override.setInterval(() => {}, 10);
+
+    timer.recover();
+    expect(clearInterval).toHaveBeenCalledWith(intervalId);
+
+    clearInterval.mockClear();
+    timer.recover();
+    expect(clearInterval).not.toHaveBeenCalled();
+  });
+});

--- a/packages/browser-vm/src/modules/timer.ts
+++ b/packages/browser-vm/src/modules/timer.ts
@@ -8,11 +8,19 @@ export const timeoutModule = (sandbox: Sandbox) => {
   const timeout = new Set<number>();
 
   const setTimeout = (handler: TimerHandler, ms?: number, ...args: any[]) => {
-    const timeoutId = rawSetTimeout(handler, ms, ...args);
-   
-    if (!sandbox.options.disableCollect) {
-      timeout.add(timeoutId);
+    if (sandbox.options.disableCollect) {
+      return rawSetTimeout(handler, ms, ...args);
     }
+
+    const callback = (...callbackArgs: any[]) => {
+      timeout.delete(timeoutId);
+      if (typeof handler === 'function') {
+        return handler.apply(window, callbackArgs);
+      }
+      return window.eval(handler);
+    };
+    const timeoutId = rawSetTimeout(callback, ms, ...args);
+    timeout.add(timeoutId);
     return timeoutId;
   };
 
@@ -25,6 +33,7 @@ export const timeoutModule = (sandbox: Sandbox) => {
     timeout.forEach((timeoutId) => {
       rawClearTimeout(timeoutId);
     });
+    timeout.clear();
   };
 
   return {
@@ -45,7 +54,7 @@ export const intervalModule = (sandbox: Sandbox) => {
     ...args: any[]
   ) => {
     const intervalId = rawSetInterval(callback, ms, ...args);
-   
+
     if (!sandbox.options.disableCollect) {
       timeout.add(intervalId);
     }
@@ -61,6 +70,7 @@ export const intervalModule = (sandbox: Sandbox) => {
     timeout.forEach((intervalId) => {
       rawClearInterval(intervalId);
     });
+    timeout.clear();
   };
 
   return {


### PR DESCRIPTION
## Summary

- Remove completed one-shot timers from sandbox tracking.
- Clear timer and interval records during sandbox recovery.
- Preserve callback arguments, callback context, and string handler support.
- Add regression tests for timer cleanup behavior.

## Problem

The browser-vm timer module retained timeout records after their callbacks had already completed. In long-lived sandboxes, these stale records could accumulate until the JavaScript engine reached the Set size limit and threw:

RangeError: Set maximum size exceeded

## Testing

- All 55 browser-vm tests passed.
- All 5 timer regression tests passed.
- The browser-vm package build passed.
- Formatting and code checks passed.