### PR TITLE
fix(ci): restore GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,6 @@ jobs:
       with:
         version: 7.6.0
         run_install: false
-    # Set up GitHub Actions caching for Wireit.
-    - uses: google/wireit@4aad131006ea85c1e42af927534ebb13426dd730 # setup-github-actions-caching/v1
     - name: install dependency
       run: pnpm install --filter=\!garfish-docs
     - name: build
@@ -81,8 +79,8 @@ jobs:
         start: node scripts/devCypress.js
         wait-on: 'http://localhost:8090,http://localhost:8091,http://localhost:8092,http://localhost:8093,http://localhost:8094,http://localhost:8095,http://localhost:8096,http://localhost:8097'
         wait-on-timeout: 600
-        parallel: true
-        record: true
+        parallel: ${{ secrets.CYPRESS_RECORD_KEY != '' }}
+        record: ${{ secrets.CYPRESS_RECORD_KEY != '' }}
       env:
         CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
         # Recommended: pass the GitHub token lets this action correctly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,8 +79,8 @@ jobs:
         start: node scripts/devCypress.js
         wait-on: 'http://localhost:8090,http://localhost:8091,http://localhost:8092,http://localhost:8093,http://localhost:8094,http://localhost:8095,http://localhost:8096,http://localhost:8097'
         wait-on-timeout: 600
-        parallel: ${{ secrets.CYPRESS_RECORD_KEY != '' }}
-        record: ${{ secrets.CYPRESS_RECORD_KEY != '' }}
+        parallel: true
+        record: true
       env:
         CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
         # Recommended: pass the GitHub token lets this action correctly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,12 @@ jobs:
       matrix:
         node-version: [16.14.0]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
       with:
         node-version: ${{ matrix.node-version }}
-    - uses: pnpm/action-setup@v2.0.1
+    - uses: pnpm/action-setup@646cdf48217256a3d0b80361c5a50727664284f2 # v2.0.1
       name: Install pnpm
       id: pnpm-install
       with:
@@ -32,7 +32,7 @@ jobs:
       run: |
         echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
       name: Setup pnpm cache
       with:
         path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
@@ -40,13 +40,13 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pnpm-store-
     # Set up GitHub Actions caching for Wireit.
-    - uses: google/wireit@setup-github-actions-caching/v1
+    - uses: google/wireit@4aad131006ea85c1e42af927534ebb13426dd730 # setup-github-actions-caching/v1
     - name: install dependency
       run: pnpm install --filter=\!garfish-docs --filter=\!@garfish-dev/\*
     - name: Run unit tests
       run: pnpm run test:coverage
     - name: Collect coverage
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # v2
       with:
         directory: ./coverage
   e2e-test:
@@ -55,19 +55,19 @@ jobs:
       matrix:
         node-version: [16.14.0]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
       with:
         node-version: ${{ matrix.node-version }}
-    - uses: pnpm/action-setup@v2.0.1
+    - uses: pnpm/action-setup@646cdf48217256a3d0b80361c5a50727664284f2 # v2.0.1
       name: Install pnpm
       id: pnpm-install
       with:
         version: 7.6.0
         run_install: false
     # Set up GitHub Actions caching for Wireit.
-    - uses: google/wireit@setup-github-actions-caching/v1
+    - uses: google/wireit@4aad131006ea85c1e42af927534ebb13426dd730 # setup-github-actions-caching/v1
     - name: install dependency
       run: pnpm install --filter=\!garfish-docs
     - name: build
@@ -75,7 +75,7 @@ jobs:
     - name: update hard link
       run: pnpm install --filter=\!garfish-docs
     - name: Run cypress test
-      uses: cypress-io/github-action@v4
+      uses: cypress-io/github-action@d79d2d530a66e641eb4a5f227e13bc985c60b964 # v4.2.2
       with:
         install: false
         start: node scripts/devCypress.js
@@ -94,12 +94,12 @@ jobs:
       matrix:
         node-version: [16.14.0]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
       with:
         node-version: ${{ matrix.node-version }}
-    - uses: pnpm/action-setup@v2.0.1
+    - uses: pnpm/action-setup@646cdf48217256a3d0b80361c5a50727664284f2 # v2.0.1
       name: Install pnpm
       id: pnpm-install
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   unit-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         node-version: [16.14.0]
@@ -50,7 +50,7 @@ jobs:
       with:
         directory: ./coverage
   e2e-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         node-version: [16.14.0]
@@ -89,7 +89,7 @@ jobs:
         # determine the unique run id necessary to re-run the checks
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   type-check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         node-version: [16.14.0]


### PR DESCRIPTION
## Summary

- Update all CI jobs from `ubuntu-20.04` to `ubuntu-22.04`.
- Pin every third-party action to a full commit SHA while retaining the existing action versions.
- Remove the end-to-end job's dependency on the unreliable remote Wireit cache.
- Keep Cypress Cloud recording and parallelization enabled as before.

## Root cause

GitHub retired the `ubuntu-20.04` hosted runner image on April 15, 2025. The workflow still requested that image, so every CI job remained queued without an assigned runner and was automatically cancelled after 24 hours.

After moving to Ubuntu 22.04, two additional CI issues became visible:

- The organization now requires actions to be pinned to full-length commit SHAs, while the workflow used moving references such as `@v2` and `@v4`.
- The end-to-end build failed repeatedly when the remote Wireit cache service returned HTTP 400 responses.

## Impact

CI jobs can now receive supported GitHub-hosted runners and pass the repository's action security policy. End-to-end builds no longer depend on the remote Wireit cache being available.

Cypress Cloud recording behavior remains unchanged and continues to require `CYPRESS_RECORD_KEY`.

## Validation

- Confirmed all three CI jobs receive Ubuntu 22.04 runners.
- Confirmed every third-party action reference is pinned to a full commit SHA.
- Confirmed unit tests and type checks pass on GitHub Actions.
- Parsed the workflow YAML successfully.
- Ran `git diff --check` successfully.

Reference: https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/